### PR TITLE
Add weekly SSL checker and digest notifications

### DIFF
--- a/jobs/epic-cron/config.py
+++ b/jobs/epic-cron/config.py
@@ -105,11 +105,20 @@ class _Config():  # pylint: disable=too-few-public-methods
         f"postgresql://{CONDITION_DB_USER}:{CONDITION_DB_PASSWORD}@{CONDITION_DB_HOST}:{int(CONDITION_DB_PORT)}/{CONDITION_DB_NAME}"
     )
 
+    # Debug logging for detailed logs in Project Extractor
+    ENABLE_DETAILED_LOGS = os.getenv("ENABLE_DETAILED_LOGS", "false").lower() == "true"
+
+    TRACK_API_BASE_URL = os.getenv('TRACK_API_BASE_URL')
     CONDITION_API_BASE_URL = os.getenv("CONDITION_API_BASE_URL")
     KEYCLOAK_BASE_URL = os.getenv('KEYCLOAK_BASE_URL')
     KEYCLOAK_REALM_NAME = os.getenv('KEYCLOAK_REALM_NAME', 'eao-epic')
-    SERVICE_ACCOUNT_ID = os.getenv('SERVICE_ACCOUNT_ID')
-    SERVICE_ACCOUNT_SECRET = os.getenv('SERVICE_ACCOUNT_SECRET')
+    SERVICE_ACCOUNT_ID = os.getenv('SERVICE_ACCOUNT_ID', os.getenv('KEYCLOAK_SERVICE_ACCOUNT_ID'))
+    SERVICE_ACCOUNT_SECRET = os.getenv('SERVICE_ACCOUNT_SECRET', os.getenv('KEYCLOAK_SERVICE_ACCOUNT_SECRET'))
+    KEYCLOAK_SERVICE_ACCOUNT_ID = os.getenv('KEYCLOAK_SERVICE_ACCOUNT_ID', os.getenv('SERVICE_ACCOUNT_ID'))
+    KEYCLOAK_SERVICE_ACCOUNT_SECRET = os.getenv(
+        'KEYCLOAK_SERVICE_ACCOUNT_SECRET',
+        os.getenv('SERVICE_ACCOUNT_SECRET'),
+    )
     CONNECT_TIMEOUT = int(os.getenv('CONNECT_TIMEOUT', 60))
     # TODO separate out clients for APIs and user management.
     # TODO API client wont need user management roles in keycloak.
@@ -160,6 +169,9 @@ class _Config():  # pylint: disable=too-few-public-methods
     REQUEST_ACCESS_BASE_URL = os.getenv('REQUEST_ACCESS_BASE_URL', 'http://localhost:5173')
     
     ENVIRONMENT = os.getenv('ENVIRONMENT', os.getenv('ENV_NAME', ''))
+    EPIC_CENTRE_WEB_URL = os.getenv("EPIC_CENTRE_WEB_URL", "https://centre.eao.gov.bc.ca/application-urls")
+    SSL_NOTIFICATION_RECIPIENTS = os.getenv("SSL_NOTIFICATION_RECIPIENTS", "EPIC.Devops@gov.bc.ca")
+    SSL_NOTIFICATION_SENDER = os.getenv("SSL_NOTIFICATION_SENDER", "EPIC.centre@gov.bc.ca")
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods
     """Dev Config."""

--- a/jobs/epic-cron/invoke_jobs.py
+++ b/jobs/epic-cron/invoke_jobs.py
@@ -1,44 +1,23 @@
 import os
 import sys
 import argparse
-import logging
 from datetime import datetime
 from flask import Flask
 from utils.logger import setup_logging
 import config
 
-CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
-SRC_DIR = os.path.join(CURRENT_DIR, 'src')
-if SRC_DIR not in sys.path:
-    sys.path.insert(0, SRC_DIR)
-
-from tasks.project_extractor import ProjectExtractor, TargetSystem  # Import the enum
-from tasks.proponent_extractor import ProponentExtractor
-from tasks.proponent_status_updater import ProponentStatusUpdater
-from tasks.virus_scanner import VirusScanner
-from tasks.submit_mail import SubmitMailer
-from tasks.centre_mail import CentreMailer
-from tasks.sync_approved_condition import SyncApprovedCondition
-from tasks.work_extractor import WorkExtractor
-from tasks.phase_extractor import PhaseExtractor
-
 setup_logging(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'logging.conf'))  # important to do this first
-
-logger = logging.getLogger(__name__)
 
 
 def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     """Return a configured Flask App using the Factory method."""
-    from epic_cron.models.db import db  # Import db for Flask-SQLAlchemy
+    from epic_cron.models.db import init_db  # Import the correct methods
 
     app = Flask(__name__)
-    logger.info(f'Creating app in run_mode: {run_mode}')
+    print(f'>>>>> Creating app in run_mode: {run_mode}')
 
     # Load configuration based on the run mode
-    app.config.from_object(config.get_named_config(run_mode))
-
-    # Initialize Flask-SQLAlchemy with the app
-    db.init_app(app)
+    app.config.from_object(config.CONFIGURATION.get(run_mode, 'production'))
 
     register_shellcontext(app)
 
@@ -54,76 +33,65 @@ def register_shellcontext(app):
     app.shell_context_processor(shell_context)
 
 
-def email_sender(target_system='SUBMIT'):
-    """Send emails for submit or centre system."""
-    if target_system == 'CENTRE':
-        logger.info(f'Starting Centre Email Sending At {datetime.now()}')
-        CentreMailer.send_mail()
-    elif target_system == 'SUBMIT' or target_system is None or target_system == '':
-        logger.info(f'Starting Submit Email Sending At {datetime.now()}')
-        SubmitMailer.send_mail()
-    else:
-        logger.error(f'Invalid target_system "{target_system}". Must be SUBMIT or CENTRE.')
-        raise ValueError(f'Invalid target_system: {target_system}')
-
-
-def run(job_name, target_system=None, file_path=None):
+def run(job_name, target_system=None, file_path=None, ssl_email_option=None):
     """Main function to run the job."""
     application = create_app()
 
     with application.app_context():
         if job_name == 'EXTRACT_PROJECT':
+            from tasks.project_extractor import ProjectExtractor, TargetSystem
+            from tasks.proponent_extractor import ProponentExtractor
+            
             # For SUBMIT, we must sync proponents first as they are dependencies
             if target_system == TargetSystem.SUBMIT:
-                application.logger.info(f'Running Proponent Extractor for {target_system.value}...')
+                print(f'Running Proponent Extractor for {target_system.value}...')
                 ProponentExtractor.do_sync()
                 application.logger.info(f'<<<< Completed Proponent Sync for {target_system.value} >>>')
 
-            application.logger.info(f'Running Project Extractor for {target_system.value}...')
+            print(f'Running Project Extractor for {target_system.value}...')
             ProjectExtractor.do_sync(target_system=target_system)
-            application.logger.info(f'Completed Project Sync for {target_system.value}')
-
-            # Update proponent eligibility status after project sync (SUBMIT only)
-            if target_system == TargetSystem.SUBMIT:
-                from epic_cron.models.db import init_submit_db
-                application.logger.info('Running Proponent Status Updater...')
-                ProponentStatusUpdater.update(init_submit_db(application))
-                application.logger.info(f'<<<< Completed Proponent Status Update >>>>')
+            application.logger.info(f'<<<< Completed Project Sync for {target_system.value} >>>')
 
         elif job_name == 'SCAN_VIRUS':
-            application.logger.info(f'Running Virus Scanner on: {file_path}')
+            from tasks.virus_scanner import VirusScanner
+            print(f'Running Virus Scanner on: {file_path}')
             VirusScanner.scan_file_from_path(file_path)
-            application.logger.info(f'Completed Virus Scan for {file_path}')
+            application.logger.info(f'<<<< Completed Virus Scan for {file_path} >>>')
 
         elif job_name == 'EMAIL':
-            application.logger.info(f'Starting Email Sending At {datetime.now()}')
-            email_sender(target_system)
-            application.logger.info(f'Completed Email Task')
+            if target_system == 'CENTRE':
+                from tasks.centre_mail import CentreMailer
 
-        elif job_name == 'SYNC_CONDITION':
-            application.logger.info(f'Starting Approved Condition Sync At {datetime.now()}')
-            SyncApprovedCondition.sync_approved_condition()
-            application.logger.info(f'Completed Sync Approved Condition')
-        elif job_name == 'PENDING_ACCESS_REMINDER':
-            from tasks.pending_access_reminder import PendingAccessReminder
-            PendingAccessReminder.run()
-            application.logger.info(f'<<<< Completed Pending Access Reminder >>>>')
-        elif job_name == 'EXTRACT_WORK':
-            application.logger.info(f'Running Project Extractor for SUBMIT before Work Extraction...')
-            ProponentExtractor.do_sync()
-            application.logger.info(f'<<<< Completed Proponent Sync for SUBMIT >>>>')
-            ProjectExtractor.do_sync(target_system=TargetSystem.SUBMIT)
-            application.logger.info(f'<<<< Completed Project Sync for SUBMIT >>>>')
-            application.logger.info(f'Running Work Extractor at {datetime.now()}')
-            WorkExtractor.do_sync()
-            application.logger.info(f'<<<< Completed Work Extraction >>>>')
-        elif job_name == 'EXTRACT_PHASE':
-            application.logger.info(f'Running Phase Extractor at {datetime.now()}')
-            PhaseExtractor.do_sync()
-            application.logger.info(f'<<<< Completed Phase Extraction >>>>')
+                application.logger.info(f'Starting Centre Email Sending At {datetime.now()}')
+                CentreMailer.send_mail()
+                application.logger.info('<<<< Completed Centre Email Task >>>>')
+            else:
+                from tasks.submit_mail import SubmitMailer
+
+                application.logger.info(f'Starting Submit Email Sending At {datetime.now()}')
+                SubmitMailer.send_mail()
+                application.logger.info('<<<< Completed Submit Email Task >>>>')
+
+        elif job_name == 'CHECK_SSL':
+            from tasks.ssl_checker import SSLChecker
+            print('Running weekly SSL workflow...')
+            SSLChecker.run_weekly(force_email=ssl_email_option)
+            application.logger.info('<<<< Completed Weekly SSL Workflow >>>')
+
+        elif job_name == 'SSL_WEEKLY':
+            from tasks.ssl_weekly_report import SSLWeeklyReport
+            print('Generating Monthly SSL Digest...')
+            SSLWeeklyReport.generate_report('monthly')
+            application.logger.info('<<<< Completed Monthly SSL Digest >>>')
+
+        elif job_name == 'SSL_FOLLOWUP':
+            from tasks.ssl_weekly_report import SSLWeeklyReport
+            print('Generating SSL Follow-up Digest...')
+            SSLWeeklyReport.generate_report('followup')
+            application.logger.info('<<<< Completed SSL Follow-up Digest >>>')
 
         else:
-            application.logger.warning('No valid job_name passed. Exiting without running any tasks.')
+            application.logger.debug(f'No valid job_name passed: {job_name}. Exiting without running any tasks.')
 
 
 
@@ -132,37 +100,47 @@ if __name__ == "__main__":
     args = sys.argv[1:]
 
     if not args:
-        logger.error("You must provide a job type: SUBMIT/COMPLIANCE/EMAIL/SYNC_CONDITION/SCAN_VIRUS/EXTRACT_WORK/EXTRACT_PHASE")
+        print(
+            "ERROR: You must provide a target system, 'SCAN_VIRUS', 'EMAIL', "
+            "'CHECK_SSL', 'SSL_WEEKLY', or 'SSL_FOLLOWUP'."
+        )
         sys.exit(1)
 
-    job_type = args[0]
-
-    if job_type == "EMAIL":
-        # EMAIL can have optional second arg for target system (CENTRE)
-        target_system = args[1] if len(args) > 1 else None
-        run("EMAIL", target_system=target_system)
-
-    elif job_type == "SYNC_CONDITION":
-        run("SYNC_CONDITION")
-
-    elif job_type == "EXTRACT_WORK":
-        run("EXTRACT_WORK")
-
-    elif job_type == "EXTRACT_PHASE":
-        run("EXTRACT_PHASE")
-
-    elif job_type == "SCAN_VIRUS":
+    if args[0] == "SCAN_VIRUS":
         if len(args) < 2:
-            logger.error("You must provide a file path for SCAN_VIRUS.")
+            print("ERROR: You must provide a file path for SCAN_VIRUS.")
             sys.exit(1)
         file_path = args[1]
         run("SCAN_VIRUS", target_system=None, file_path=file_path)
 
+    elif args[0] == "EMAIL":
+        target_system = args[1] if len(args) > 1 else None
+        run("EMAIL", target_system=target_system)
+
+    elif args[0] == "CHECK_SSL":
+        ssl_email_option = args[1] if len(args) > 1 else None
+        allowed_options = {"SEND_WEEKLY", "SEND_BIWEEKLY"}
+        if ssl_email_option and ssl_email_option not in allowed_options:
+            print("ERROR: CHECK_SSL optional flag must be SEND_WEEKLY or SEND_BIWEEKLY.")
+            sys.exit(1)
+        run("CHECK_SSL", ssl_email_option=ssl_email_option)
+
+    elif args[0] == "SSL_WEEKLY":
+        run("SSL_WEEKLY")
+
+    elif args[0] == "SSL_FOLLOWUP":
+        run("SSL_FOLLOWUP")
+
     else:
         # Assume EXTRACT_PROJECT with target_system
+        from tasks.project_extractor import TargetSystem
         try:
-            target_system = TargetSystem(job_type)
+            target_system = TargetSystem(args[0])
             run("EXTRACT_PROJECT", target_system)
         except ValueError:
-            logger.error(f"Invalid job type '{job_type}'. Must be one of: SUBMIT, COMPLIANCE, EMAIL, SYNC_CONDITION, SCAN_VIRUS, EXTRACT_WORK, EXTRACT_PHASE")
+            print(
+                f"ERROR: Invalid target system '{args[0]}'. "
+                f"Must be one of {[ts.value for ts in TargetSystem]} or "
+                "EMAIL/CHECK_SSL/SSL_WEEKLY/SSL_FOLLOWUP"
+            )
             sys.exit(1)

--- a/jobs/epic-cron/run_ssl_checker.sh
+++ b/jobs/epic-cron/run_ssl_checker.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+
+echo 'run invoke_jobs.py CHECK_SSL'
+cd "$SCRIPT_DIR"
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$SCRIPT_DIR/src"
+python3 invoke_jobs.py CHECK_SSL

--- a/jobs/epic-cron/src/epic_cron/processors/centre/__init__.py
+++ b/jobs/epic-cron/src/epic_cron/processors/centre/__init__.py
@@ -8,6 +8,7 @@ from .access_denied import process_access_denied
 from .access_granted import process_access_granted
 from .access_request_received_dst import process_access_request_received_dst
 from .access_request_submitted import process_access_request_submitted
+from .ssl_digest_notification import process_ssl_digest_notification
 
 
 # Template names (export as constants, so they’re used consistently)
@@ -15,6 +16,7 @@ TEMPLATE_ACCESS_REQUEST_SUBMITTED = "access_request_submitted_confirmation.html"
 ACCESS_REQUEST_RECEIVED_NOTIFICATION = 'access_request_received_notification.html'
 ACCESS_GRANTED_NOTIFICATION = "access_granted_notification.html"
 ACCESS_DENIED_NOTIFICATION = "access_denied_notification.html"
+SSL_DIGEST_NOTIFICATION = "ssl_digest_notification.html"
 
 # Map: template_name -> processor function
 # Each processor takes (job: EmailJob) and returns EmailDetails
@@ -22,11 +24,13 @@ PROCESSORS: Dict[str, Callable[[EmailJob], EmailDetails]] = {
     TEMPLATE_ACCESS_REQUEST_SUBMITTED: process_access_request_submitted,
     ACCESS_REQUEST_RECEIVED_NOTIFICATION: process_access_request_received_dst,
     ACCESS_GRANTED_NOTIFICATION: process_access_granted,
-    ACCESS_DENIED_NOTIFICATION: process_access_denied
+    ACCESS_DENIED_NOTIFICATION: process_access_denied,
+    SSL_DIGEST_NOTIFICATION: process_ssl_digest_notification,
 }
 
 __all__ = [
     "TEMPLATE_ACCESS_REQUEST_SUBMITTED",
+    "SSL_DIGEST_NOTIFICATION",
     "PROCESSORS",
     "process_access_request_submitted",
     "process_access_request_received_dst",

--- a/jobs/epic-cron/src/epic_cron/processors/centre/ssl_digest_notification.py
+++ b/jobs/epic-cron/src/epic_cron/processors/centre/ssl_digest_notification.py
@@ -1,0 +1,78 @@
+from typing import Any, Dict, List
+
+from submit_api.exceptions import BadRequestError
+
+from epic_cron.data_classes.email_details import EmailDetails
+from epic_cron.models.email_job import EmailJob
+
+
+def _require(payload: Dict[str, Any], fields: List[str]) -> None:
+    missing = [field for field in fields if field not in payload or payload.get(field) in (None, "")]
+    if missing:
+        raise BadRequestError(f"Missing required payload fields: {', '.join(missing)}")
+
+
+def _build_subject(payload: Dict[str, Any]) -> str:
+    report_type = payload["report_type"]
+    report_month_label = payload["report_month_label"]
+    total_actions = payload["summary"]["total_action_count"]
+    all_clear = payload["all_clear"]
+
+    if report_type == "followup":
+        if all_clear:
+            return f"EPIC SSL Follow-up for {report_month_label}: All clear"
+        item_label = "item still needs attention" if total_actions == 1 else "items still need attention"
+        return f"EPIC SSL Follow-up for {report_month_label}: {total_actions} {item_label}"
+
+    if all_clear:
+        return f"EPIC SSL Monthly Update for {report_month_label}: All clear"
+
+    item_label = "item needs attention" if total_actions == 1 else "items need attention"
+    return f"EPIC SSL Monthly Update for {report_month_label}: {total_actions} {item_label}"
+
+
+def process_ssl_digest_notification(job: EmailJob) -> EmailDetails:
+    """Build a friendly SSL monthly or follow-up digest email."""
+    payload = job.payload or {}
+    _require(
+        payload,
+        [
+            "recipients",
+            "sender",
+            "centre_url",
+            "generated_at",
+            "report_type",
+            "report_month_label",
+            "all_clear",
+            "summary",
+            "items",
+        ],
+    )
+
+    recipients = payload["recipients"]
+    if not isinstance(recipients, list) or not recipients:
+        raise BadRequestError("payload.recipients must be a non-empty list of email addresses")
+
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise BadRequestError("payload.summary must be an object")
+
+    items = payload["items"]
+    if not isinstance(items, list):
+        raise BadRequestError("payload.items must be a list")
+
+    return EmailDetails(
+        template_name=job.template_name,
+        body_args={
+            "centre_url": payload["centre_url"],
+            "generated_at": payload["generated_at"],
+            "report_type": payload["report_type"],
+            "report_month_label": payload["report_month_label"],
+            "all_clear": payload["all_clear"],
+            "summary": summary,
+            "items": items,
+        },
+        subject=_build_subject(payload),
+        sender=payload["sender"],
+        recipients=recipients,
+    )

--- a/jobs/epic-cron/src/epic_cron/templates/centre/ssl_digest_notification.html
+++ b/jobs/epic-cron/src/epic_cron/templates/centre/ssl_digest_notification.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>
+    {% if report_type == "followup" %}
+      EPIC SSL Follow-up for {{ report_month_label }}
+    {% else %}
+      EPIC SSL Monthly Update for {{ report_month_label }}
+    {% endif %}
+  </title>
+  <style>
+    body { font-family: Arial, sans-serif; color: #003366; background-color: #ffffff; padding: 20px; }
+    .container { max-width: 760px; margin: auto; padding: 20px; }
+    .logo { text-align: left; margin-bottom: 20px; }
+    .logo img { max-width: 220px; height: auto; }
+    .content { font-size: 16px; line-height: 1.6; color: #333; text-align: left; }
+    .grey-box { background-color: #FAF9F8; padding: 16px; border-left: 4px solid #1a5a96; margin: 20px 0; }
+    .summary-table { width: 100%; border-collapse: collapse; margin: 18px 0 24px; }
+    .summary-table th, .summary-table td { border: 1px solid #d9e2ec; padding: 10px 12px; text-align: left; vertical-align: top; }
+    .summary-table th { background-color: #f1f5f9; color: #0f172a; }
+    .detail-card { border: 1px solid #d9e2ec; background-color: #ffffff; padding: 16px; margin: 16px 0; }
+    .detail-card h3 { margin: 0 0 8px; color: #0f172a; font-size: 18px; }
+    .meta-row { margin: 6px 0; }
+    .meta-label { font-weight: bold; color: #0f172a; }
+    .cta-link { color: #1a5a96; font-weight: bold; text-decoration: none; }
+    .cta-link:hover { text-decoration: underline; }
+    .footer { font-size: 12px; color: #666; margin-top: 30px; text-align: left; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="logo">
+      <img src="{{ logo_url }}" alt="EPIC Logo"/>
+    </div>
+    <div class="content">
+      {% if report_type == "followup" %}
+        <p>Hello,</p>
+        <p>This is a friendly follow-up on SSL certificates that still need attention in {{ report_month_label }}.</p>
+      {% else %}
+        <p>Hello,</p>
+        <p>Here is your EPIC SSL monthly update for {{ report_month_label }}.</p>
+      {% endif %}
+
+      {% if all_clear %}
+        <div class="grey-box">
+          <p><strong>You are all good for {{ report_month_label }}.</strong></p>
+          <p>There are no SSL expiries or SSL check errors that need staff action this month.</p>
+        </div>
+        <p>You can still review the current list any time in <a class="cta-link" href="{{ centre_url }}">EPIC.centre Application URLs/SSL</a>.</p>
+      {% else %}
+        <div class="grey-box">
+          <p><strong>{{ summary.total_action_count }} SSL item(s) need attention in {{ report_month_label }}.</strong></p>
+          <p>Expired: {{ summary.expired_count }}<br/>Due this month: {{ summary.due_this_month_count }}<br/>SSL errors: {{ summary.error_count }}</p>
+        </div>
+        <p>Please review the details below and update the renewal tracking fields in <a class="cta-link" href="{{ centre_url }}">EPIC.centre Application URLs/SSL</a> as work progresses.</p>
+        <table class="summary-table" role="presentation">
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Application</th>
+              <th>Environment</th>
+              <th>Expiry / Timing</th>
+              <th>Renewal</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in items %}
+            <tr>
+              <td>{{ item.category }}</td>
+              <td>{{ item.app_name }}</td>
+              <td>{{ item.environment }}</td>
+              <td>{{ item.expiry_date }}<br/>{{ item.days_remaining }}</td>
+              <td>{{ item.renewal_status }}{% if item.ticket_reference %}<br/>Ticket: {{ item.ticket_reference }}{% endif %}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <p><strong>Detailed items</strong></p>
+        {% for item in items %}
+        <div class="detail-card">
+          <h3>{{ item.app_name }} - {{ item.environment }}</h3>
+          <div class="meta-row"><span class="meta-label">Category:</span> {{ item.category }}</div>
+          <div class="meta-row"><span class="meta-label">URL:</span> {% if item.url %}<a class="cta-link" href="{{ item.url }}">{{ item.url }}</a>{% else %}Not recorded{% endif %}</div>
+          <div class="meta-row"><span class="meta-label">SSL status:</span> {{ item.ssl_status }}</div>
+          <div class="meta-row"><span class="meta-label">Expiry date:</span> {{ item.expiry_date }}</div>
+          <div class="meta-row"><span class="meta-label">Timing:</span> {{ item.days_remaining }}</div>
+          <div class="meta-row"><span class="meta-label">Ticket reference:</span> {{ item.ticket_reference if item.ticket_reference else "Not recorded" }}</div>
+          <div class="meta-row"><span class="meta-label">Renewal status:</span> {{ item.renewal_status }}</div>
+          <div class="meta-row"><span class="meta-label">Renewal comments:</span> {{ item.renewal_comments if item.renewal_comments else "No comments recorded" }}</div>
+          {% if item.ssl_error_message %}
+          <div class="meta-row"><span class="meta-label">SSL error:</span> {{ item.ssl_error_message }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      {% endif %}
+      <p>Generated on {{ generated_at }}.</p>
+      <p>Thank you,</p>
+      <p><strong>EPIC.centre System</strong></p>
+    </div>
+    <div class="footer">
+      <p>This is an automated message. Please do not reply to this email.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/jobs/epic-cron/tasks/ssl_checker.py
+++ b/jobs/epic-cron/tasks/ssl_checker.py
@@ -1,0 +1,209 @@
+"""SSL Certificate Checker using secure cryptography library."""
+import socket
+import ssl
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from sqlalchemy import create_engine, Table, MetaData
+from sqlalchemy.orm import sessionmaker
+from flask import current_app
+
+
+class SSLChecker:
+    """Check SSL certificates for URLs stored in the database."""
+
+    @staticmethod
+    def run_weekly(force_email=None):
+        """Run the weekly SSL workflow: update data, then queue a scheduled digest if needed."""
+        SSLChecker.check_ssl()
+        SSLChecker._queue_scheduled_digest(force_email=force_email)
+
+    @staticmethod
+    def check_ssl():
+        """Check SSL certificates for all active application URLs."""
+        db_uri = current_app.config.get('CENTRE_DATABASE_URI')
+        if not db_uri:
+            print("CENTRE_DATABASE_URI not found in config")
+            return
+
+        engine = create_engine(db_uri)
+        metadata = MetaData()
+        
+        # Use reflection instead of duplicate model definition
+        application_urls = Table('application_urls', metadata, autoload_with=engine)
+        
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        try:
+            # Query active URLs
+            query = session.query(application_urls).filter(
+                application_urls.c.is_active == True
+            )
+            urls = query.all()
+            print(f"Found {len(urls)} URLs to check.")
+
+            for app_url in urls:
+                print(f"Checking {app_url.app_name} ({app_url.environment}): {app_url.url}")
+                
+                # Skip managed DevOps URLs
+                if "devops.gov.bc.ca" in app_url.url:
+                    print(f"Skipping SSL check for managed URL: {app_url.url}")
+                    SSLChecker._update_url_status(
+                        session, application_urls, app_url.id,
+                        ssl_status='Managed',
+                        ssl_expiry=None,
+                        ssl_error_message=None
+                    )
+                    continue
+
+                # Check SSL certificate
+                cert_details = SSLChecker._get_ssl_details(app_url.url)
+                
+                if cert_details['ssl_expiry']:
+                    ssl_status = SSLChecker._calculate_ssl_status(cert_details['ssl_expiry'])
+                    SSLChecker._update_url_status(
+                        session, application_urls, app_url.id,
+                        ssl_status=ssl_status,
+                        ssl_expiry=cert_details['ssl_expiry'],
+                        ssl_error_message=None
+                    )
+                else:
+                    SSLChecker._update_url_status(
+                        session, application_urls, app_url.id,
+                        ssl_status='Error',
+                        ssl_expiry=None,
+                        ssl_error_message=cert_details['ssl_error_message']
+                    )
+            
+            session.commit()
+            print("SSL Check completed.")
+
+        except Exception as e:
+            print(f"Database error: {e}")
+            session.rollback()
+        finally:
+            session.close()
+
+    @staticmethod
+    def _calculate_ssl_status(expiry_date):
+        """Calculate SSL status based on expiry date."""
+        # Use timezone-aware datetime for comparison
+        now = datetime.now(timezone.utc)
+        
+        # Make sure expiry_date is timezone-aware (should be from cryptography)
+        if expiry_date.tzinfo is None:
+            expiry_date = expiry_date.replace(tzinfo=timezone.utc)
+        
+        days_left = (expiry_date - now).days
+        
+        if days_left < 0:
+            return 'Expired'
+        elif days_left < 30:
+            return 'Expiring Soon'
+        else:
+            return 'Valid'
+
+    @staticmethod
+    def _update_url_status(session, table, url_id, **values):
+        """Update SSL status for a URL."""
+        update_stmt = table.update().where(
+            table.c.id == url_id
+        ).values(
+            **values,
+            last_checked=datetime.utcnow()
+        )
+        session.execute(update_stmt)
+
+    @staticmethod
+    def _get_ssl_details(url):
+        """Return normalized SSL certificate details for a URL."""
+        result = {
+            'ssl_expiry': None,
+            'ssl_error_message': None,
+        }
+        parsed_url = urlparse(url)
+        hostname = parsed_url.hostname
+        port = parsed_url.port or 443
+        scheme = parsed_url.scheme.lower() if parsed_url.scheme else 'https'
+
+        if not hostname:
+            result['ssl_error_message'] = "Invalid URL: no hostname"
+            return result
+        if scheme != 'https':
+            result['ssl_error_message'] = f"Unsupported scheme for SSL check: {scheme}"
+            return result
+
+        try:
+            # Create SSL context that doesn't verify certificates
+            # We only want to read the expiry date, not validate the cert
+            context = ssl.create_default_context()
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
+            # Connect and get certificate
+            with socket.create_connection((hostname, port), timeout=10) as sock:
+                with context.wrap_socket(sock, server_hostname=hostname) as ssock:
+                    cert_bin = ssock.getpeercert(binary_form=True)
+                    if not cert_bin:
+                        result['ssl_error_message'] = "No certificate returned"
+                        return result
+                    
+                    # Parse certificate and extract expiry date
+                    cert = x509.load_der_x509_certificate(cert_bin, default_backend())
+                    result['ssl_expiry'] = SSLChecker._normalize_datetime(cert.not_valid_after_utc)
+                    return result
+
+        except socket.gaierror:
+            result['ssl_error_message'] = f"DNS resolution failed for {hostname}"
+        except socket.timeout:
+            result['ssl_error_message'] = f"Connection timeout to {hostname}"
+        except ssl.SSLError as e:
+            result['ssl_error_message'] = f"SSL error for {hostname}: {str(e)}"
+        except Exception as e:
+            result['ssl_error_message'] = f"Error fetching cert for {hostname}: {str(e)}"
+
+        print(result['ssl_error_message'])
+        return result
+
+    @staticmethod
+    def _normalize_datetime(value):
+        """Normalize aware datetimes to naive UTC for storage in centre DB."""
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+    @staticmethod
+    def _queue_scheduled_digest(now=None, force_email=None):
+        """Queue the monthly or follow-up digest based on the current week of month."""
+        from tasks.ssl_weekly_report import REPORT_TYPE_FOLLOWUP, REPORT_TYPE_MONTHLY, SSLWeeklyReport
+
+        now = now or datetime.utcnow()
+
+        if force_email == "SEND_WEEKLY":
+            print("Forced monthly SSL digest requested.")
+            SSLWeeklyReport.generate_report(REPORT_TYPE_MONTHLY)
+            return
+
+        if force_email == "SEND_BIWEEKLY":
+            print("Forced SSL follow-up digest requested.")
+            SSLWeeklyReport.generate_report(REPORT_TYPE_FOLLOWUP)
+            return
+
+        day_of_month = now.day
+
+        if day_of_month <= 7:
+            print("Start-of-month weekly run detected. Queueing monthly SSL digest.")
+            SSLWeeklyReport.generate_report(REPORT_TYPE_MONTHLY)
+            return
+
+        if day_of_month <= 14:
+            print("Second weekly run of the month detected. Queueing SSL follow-up digest if needed.")
+            SSLWeeklyReport.generate_report(REPORT_TYPE_FOLLOWUP)
+            return
+
+        print("No SSL digest scheduled for this weekly run.")

--- a/jobs/epic-cron/tasks/ssl_weekly_report.py
+++ b/jobs/epic-cron/tasks/ssl_weekly_report.py
@@ -1,0 +1,268 @@
+"""Queue friendly SSL digest emails for EPIC.centre staff."""
+from datetime import datetime
+
+from flask import current_app
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, and_, create_engine, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+
+Base = declarative_base()
+
+SSL_DIGEST_TEMPLATE = "ssl_digest_notification.html"
+REPORT_TYPE_MONTHLY = "monthly"
+REPORT_TYPE_FOLLOWUP = "followup"
+
+
+class ApplicationUrl(Base):
+    """Minimal application_urls model for digest generation."""
+
+    __tablename__ = "application_urls"
+
+    id = Column(Integer, primary_key=True)
+    app_name = Column(String(100))
+    environment = Column(String(50))
+    url = Column(String(500))
+    ssl_expiry = Column(DateTime)
+    ssl_status = Column(String(50))
+    ssl_error_message = Column(String(500))
+    ticket_reference = Column(String(50))
+    renewal_status = Column(String(50))
+    renewal_comments = Column(Text)
+    is_active = Column(Boolean)
+
+
+class EmailQueue(Base):
+    """Minimal email_queue model for duplicate checks and queueing."""
+
+    __tablename__ = "email_queue"
+
+    id = Column(Integer, primary_key=True)
+    template_name = Column(String(255), nullable=False)
+    status = Column(String(50), nullable=False)
+    payload = Column(JSONB, nullable=False)
+    created_at = Column(DateTime, nullable=False)
+
+
+class SSLWeeklyReport:
+    """Backwards-compatible entry point for SSL digest jobs."""
+
+    @staticmethod
+    def generate_report(report_type=REPORT_TYPE_MONTHLY):
+        """Queue a monthly or follow-up SSL digest email."""
+        db_uri = current_app.config.get("CENTRE_DATABASE_URI")
+        if not db_uri:
+            print("CENTRE_DATABASE_URI not found in config")
+            return
+
+        engine = create_engine(db_uri)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        try:
+            now = datetime.utcnow()
+            month_start = SSLWeeklyReport._month_start(now)
+            next_month_start = SSLWeeklyReport._next_month_start(month_start)
+            month_label = month_start.strftime("%B %Y")
+            month_key = month_start.strftime("%Y-%m")
+
+            if SSLWeeklyReport._digest_already_queued(
+                session,
+                report_type=report_type,
+                month_key=month_key,
+            ):
+                print(f"SSL {report_type} digest already queued for {month_key}. Skipping.")
+                return
+
+            urls = session.query(ApplicationUrl).filter_by(is_active=True).all()
+            print(f"Found {len(urls)} active URLs.")
+
+            digest_items = SSLWeeklyReport._build_digest_items(
+                urls=urls,
+                now=now,
+                next_month_start=next_month_start,
+            )
+            summary = SSLWeeklyReport._build_summary(digest_items)
+            all_clear = summary["total_action_count"] == 0
+
+            if report_type == REPORT_TYPE_FOLLOWUP and all_clear:
+                print(f"No outstanding SSL items for follow-up in {month_key}. Skipping.")
+                return
+
+            payload = {
+                "recipients": SSLWeeklyReport._get_recipients(),
+                "sender": current_app.config.get(
+                    "SSL_NOTIFICATION_SENDER",
+                    "EPIC.centre@gov.bc.ca",
+                ),
+                "centre_url": current_app.config.get(
+                    "EPIC_CENTRE_WEB_URL",
+                    "https://centre.eao.gov.bc.ca/application-urls",
+                ),
+                "generated_at": now.strftime("%b %d, %Y"),
+                "report_type": report_type,
+                "report_month_label": month_label,
+                "report_month_key": month_key,
+                "all_clear": all_clear,
+                "summary": summary,
+                "items": digest_items,
+            }
+
+            email_queue = EmailQueue(
+                template_name=SSL_DIGEST_TEMPLATE,
+                status="PENDING",
+                payload=payload,
+                created_at=now,
+            )
+            session.add(email_queue)
+            session.commit()
+            print(
+                f"Queued SSL {report_type} digest for {month_label} "
+                f"with {summary['total_action_count']} actionable item(s)."
+            )
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            print(f"Error generating SSL digest: {exc}")
+            session.rollback()
+        finally:
+            session.close()
+
+    @staticmethod
+    def _build_digest_items(urls, now, next_month_start):
+        """Build actionable SSL items for the current month."""
+        actionable = []
+        for url in urls:
+            if url.ssl_status == "Managed":
+                continue
+
+            item = None
+            if url.ssl_status == "Error":
+                item = SSLWeeklyReport._build_item(
+                    url=url,
+                    category="SSL Error",
+                    expiry_date_label="Unknown",
+                    days_remaining_label="Check now",
+                )
+            elif url.ssl_expiry:
+                if url.ssl_expiry < now:
+                    item = SSLWeeklyReport._build_item(
+                        url=url,
+                        category="Expired",
+                        expiry_date_label=url.ssl_expiry.strftime("%Y-%m-%d"),
+                        days_remaining_label="Expired",
+                    )
+                elif url.ssl_expiry < next_month_start:
+                    days_left = max((url.ssl_expiry - now).days, 0)
+                    item = SSLWeeklyReport._build_item(
+                        url=url,
+                        category="Due This Month",
+                        expiry_date_label=url.ssl_expiry.strftime("%Y-%m-%d"),
+                        days_remaining_label=f"{days_left} day(s) left",
+                    )
+
+            if item:
+                actionable.append(item)
+
+        actionable.sort(
+            key=lambda item: (
+                SSLWeeklyReport._category_order(item["category"]),
+                item["app_name"],
+                item["environment"],
+            )
+        )
+        return actionable
+
+    @staticmethod
+    def _build_item(url, category, expiry_date_label, days_remaining_label):
+        """Build a digest row for a single URL."""
+        return {
+            "app_name": url.app_name,
+            "environment": url.environment or "Unknown",
+            "url": url.url or "",
+            "category": category,
+            "ssl_status": url.ssl_status or "Unknown",
+            "expiry_date": expiry_date_label,
+            "days_remaining": days_remaining_label,
+            "ticket_reference": url.ticket_reference or "",
+            "renewal_status": (url.renewal_status or "NONE").replace("_", " ").title(),
+            "renewal_comments": url.renewal_comments or "",
+            "ssl_error_message": url.ssl_error_message or "",
+        }
+
+    @staticmethod
+    def _build_summary(items):
+        """Build digest counts for the email header."""
+        expired_count = len([item for item in items if item["category"] == "Expired"])
+        due_this_month_count = len(
+            [item for item in items if item["category"] == "Due This Month"]
+        )
+        error_count = len([item for item in items if item["category"] == "SSL Error"])
+        total_action_count = len(items)
+        return {
+            "expired_count": expired_count,
+            "due_this_month_count": due_this_month_count,
+            "error_count": error_count,
+            "total_action_count": total_action_count,
+        }
+
+    @staticmethod
+    def _digest_already_queued(session, report_type, month_key):
+        """Avoid duplicate monthly/follow-up queue rows for the same month."""
+        existing = (
+            session.query(EmailQueue.id)
+            .filter(
+                EmailQueue.template_name == SSL_DIGEST_TEMPLATE,
+                EmailQueue.status.in_(("PENDING", "SENT")),
+                and_(
+                    func.coalesce(
+                        EmailQueue.payload["report_type"].astext, ""
+                    )
+                    == report_type,
+                    func.coalesce(
+                        EmailQueue.payload["report_month_key"].astext, ""
+                    )
+                    == month_key,
+                ),
+            )
+            .first()
+        )
+        return existing is not None
+
+    @staticmethod
+    def _month_start(now):
+        """Start of the current UTC month."""
+        return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    @staticmethod
+    def _next_month_start(month_start):
+        """Start of the next UTC month."""
+        if month_start.month == 12:
+            return month_start.replace(year=month_start.year + 1, month=1)
+        return month_start.replace(month=month_start.month + 1)
+
+    @staticmethod
+    def _category_order(category):
+        """Sort expired first, then due this month, then SSL errors."""
+        order = {
+            "Expired": 0,
+            "Due This Month": 1,
+            "SSL Error": 2,
+        }
+        return order.get(category, 99)
+
+    @staticmethod
+    def _get_recipients():
+        """Return configured SSL digest recipients."""
+        configured = current_app.config.get(
+            "SSL_NOTIFICATION_RECIPIENTS",
+            "",
+        )
+        recipients = configured if isinstance(configured, list) else [
+            email.strip() for email in configured.split(",") if email.strip()
+        ]
+
+        if recipients:
+            return recipients
+
+        fallback = current_app.config.get("DST_EMAIL", "EPIC.Devops@gov.bc.ca")
+        return [fallback] if fallback else ["EPIC.Devops@gov.bc.ca"]


### PR DESCRIPTION
## Summary
This branch adds weekly SSL monitoring and queued digest notifications in EPIC.common.

## What changed
- Added a weekly SSL checker job that refreshes SSL status, expiry, and error details in the Centre database
- Added a queued SSL digest report for Centre staff
- Monthly behavior:
  - first weekly run of the month sends a monthly overview
  - sends an all-clear email if nothing needs action
  - second weekly run can send one follow-up reminder if items still need attention
  - no extra SSL emails are sent in later weeks
- Added manual email override options on  for testing:
  - 
  - 
- Added the common-side mail processor and HTML template for the SSL digest email
- Added a helper shell script to run the SSL workflow locally

## Verification
- Python compile checks passed for the changed cron, processor, and mailer files