### PR TITLE
Refactor dependencies

### DIFF
--- a/jobs/epic-cron/invoke_jobs.py
+++ b/jobs/epic-cron/invoke_jobs.py
@@ -86,9 +86,9 @@ def run(job_name, target_system=None, file_path=None, ssl_email_option=None):
 
             # Update proponent eligibility status after project sync (SUBMIT only)
             if target_system == TargetSystem.SUBMIT:
-                from epic_cron.models.db import init_submit_db
+                from epic_cron.models.db import init_submit_session
                 application.logger.info('Running Proponent Status Updater...')
-                ProponentStatusUpdater.update(init_submit_db(application))
+                ProponentStatusUpdater.update(init_submit_session(application))
                 application.logger.info(f'<<<< Completed Proponent Status Update >>>>')
 
         elif job_name == 'SCAN_VIRUS':

--- a/jobs/epic-cron/requirements.txt
+++ b/jobs/epic-cron/requirements.txt
@@ -60,5 +60,3 @@ urllib3==2.6.3
 Werkzeug==3.1.8
 -e git+https://github.com/bcgov/EPIC.submit.git@develop#egg=submit-api&subdirectory=submit-api
 #-e git+https://github.com/bcgov/EPIC.track.git@develop#egg=api&subdirectory=epictrack-api
--e git+https://github.com/bcgov/EPIC.compliance.git@develop#egg=compliance-api&subdirectory=compliance-api
--e git+https://github.com/bcgov/EPIC.conditions.git@main#egg=condition-api&subdirectory=condition-api

--- a/jobs/epic-cron/requirements/repo-libraries.txt
+++ b/jobs/epic-cron/requirements/repo-libraries.txt
@@ -1,4 +1,2 @@
 -e git+https://github.com/bcgov/EPIC.submit.git@develop#egg=submit-api&subdirectory=submit-api
 #-e git+https://github.com/bcgov/EPIC.track.git@develop#egg=api&subdirectory=epictrack-api
--e git+https://github.com/bcgov/EPIC.compliance.git@develop#egg=compliance-api&subdirectory=compliance-api
--e git+https://github.com/bcgov/EPIC.conditions.git@main#egg=condition-api&subdirectory=condition-api

--- a/jobs/epic-cron/src/epic_cron/models/db.py
+++ b/jobs/epic-cron/src/epic_cron/models/db.py
@@ -56,6 +56,12 @@ def init_submit_db(app):
     return db
 
 
+def init_submit_session(app):
+    """Initialize a session factory for the Submit database."""
+    print("Initializing Submit database session...")
+    return create_session(app.config['SUBMIT_DATABASE_URI'])
+
+
 # Aliases for backward compatibility
 def init_db(app):
     """Initialize the session for the Track database (alias for init_track_db)."""

--- a/jobs/epic-cron/src/epic_cron/models/db.py
+++ b/jobs/epic-cron/src/epic_cron/models/db.py
@@ -1,5 +1,7 @@
 """Initializations for db and marshmallow."""
 
+from contextlib import contextmanager
+
 from flask_marshmallow import Marshmallow
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import create_engine
@@ -22,6 +24,19 @@ def create_session(engine_uri):
         pool_recycle=3600
     )
     return sessionmaker(bind=engine)
+
+
+@contextmanager
+def session_scope(session_factory):
+    """Create a session, rollback on failure, and always close it."""
+    session = session_factory()
+    try:
+        yield session
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
 
 def init_track_db(app):

--- a/jobs/epic-cron/src/epic_cron/models/external/submit.py
+++ b/jobs/epic-cron/src/epic_cron/models/external/submit.py
@@ -1,0 +1,39 @@
+"""Local Submit models used by epic-cron sync jobs."""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, Column, DateTime, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+
+class SubmitProject(Base):
+    """Minimal Submit project mapping for sync jobs."""
+
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    epic_guid = Column(String, nullable=True)
+    proponent_id = Column(Integer, nullable=True)
+    ea_certificate = Column(String, nullable=True)
+    has_approved_condition = Column(Boolean, default=False, nullable=False)
+
+
+class SubmitProponent(Base):
+    """Minimal Submit proponent mapping for sync jobs."""
+
+    __tablename__ = "proponents"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    status = Column(String(50), nullable=True)
+    is_deleted = Column(Boolean, default=False, nullable=False)
+    created_date = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=True)
+    updated_date = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=True,
+    )

--- a/jobs/epic-cron/src/epic_cron/services/approved_condition_service.py
+++ b/jobs/epic-cron/src/epic_cron/services/approved_condition_service.py
@@ -1,6 +1,6 @@
 import requests
 from flask import current_app
-from submit_api.models.project import Project as SubmitProjectModel
+from epic_cron.models.external.submit import SubmitProject
 
 class ApprovedConditionService:
     """Service to interact with the Condition API."""
@@ -47,8 +47,8 @@ class ApprovedConditionService:
 
             # Update Projects
             print(f"Updating projects matching {len(epic_guids)} GUIDs...")
-            projects_to_update = session.query(SubmitProjectModel).filter(
-                SubmitProjectModel.epic_guid.in_(epic_guids)
+            projects_to_update = session.query(SubmitProject).filter(
+                SubmitProject.epic_guid.in_(epic_guids)
             ).all()
 
             proponent_ids_to_update = set()

--- a/jobs/epic-cron/src/epic_cron/services/approved_condition_sync_service.py
+++ b/jobs/epic-cron/src/epic_cron/services/approved_condition_sync_service.py
@@ -1,15 +1,13 @@
 import requests
 from flask import current_app
-from submit_api.models.project import Project
-
-from epic_cron.models import db
+from epic_cron.models.external.submit import SubmitProject
 
 
 class ApprovedConditionService:
     """Service to interact with the Condition API."""
 
     @staticmethod
-    def sync_projects_with_approved_conditions():
+    def sync_projects_with_approved_conditions(session_factory):
         """
         Fetch project data from the Condition API
 
@@ -39,32 +37,26 @@ class ApprovedConditionService:
             current_app.logger.info(f"Condition API returned {len(projects)} projects.")
 
             epic_guids = [p.get("epic_guid") for p in projects if p.get("epic_guid")]
-
             updated_count = 0
 
-            for epic_guid in epic_guids:
-                # Fetch the Project by epic_guid
-                project = db.session.query(Project).filter_by(epic_guid=epic_guid).first()
-                if project:
-                    if not project.has_approved_condition:
+            with session_factory() as session:
+                for epic_guid in epic_guids:
+                    project = session.query(SubmitProject).filter_by(epic_guid=epic_guid).first()
+                    if project and not project.has_approved_condition:
                         project.has_approved_condition = True
                         updated_count += 1
 
-            db.session.commit()
+                session.commit()
 
             current_app.logger.info(f"Updated {updated_count} projects with has_approved_condition=True.")
             return {"updated_projects": updated_count}
 
         except requests.RequestException as e:
-            db.session.rollback()
             current_app.logger.error(f"Error while calling Condition API: {e}")
             raise
         except Exception as e:
-            db.session.rollback()
             current_app.logger.error(f"Unexpected error: {e}")
             raise
-        finally:
-            db.session.remove()
 
     @staticmethod
     def _get_admin_token():

--- a/jobs/epic-cron/src/epic_cron/services/approved_condition_sync_service.py
+++ b/jobs/epic-cron/src/epic_cron/services/approved_condition_sync_service.py
@@ -1,6 +1,7 @@
 import requests
 from flask import current_app
 from epic_cron.models.external.submit import SubmitProject
+from epic_cron.models.db import session_scope
 
 
 class ApprovedConditionService:
@@ -39,7 +40,7 @@ class ApprovedConditionService:
             epic_guids = [p.get("epic_guid") for p in projects if p.get("epic_guid")]
             updated_count = 0
 
-            with session_factory() as session:
+            with session_scope(session_factory) as session:
                 for epic_guid in epic_guids:
                     project = session.query(SubmitProject).filter_by(epic_guid=epic_guid).first()
                     if project and not project.has_approved_condition:

--- a/jobs/epic-cron/src/epic_cron/services/track_service.py
+++ b/jobs/epic-cron/src/epic_cron/services/track_service.py
@@ -1,7 +1,7 @@
 from flask import current_app
 from sqlalchemy import MetaData, Table, select, func
 
-from epic_cron.models.db import init_db
+from epic_cron.models.db import init_db, session_scope
 
 
 class TrackService:
@@ -13,7 +13,7 @@ class TrackService:
         current_app.logger.info("Fetching proponents from track database...")
 
         track_session = init_db(current_app)
-        with track_session() as session:
+        with session_scope(track_session) as session:
             track_metadata = MetaData()
             track_proponents_table = Table('proponents', track_metadata, autoload_with=session.bind)
 
@@ -38,7 +38,7 @@ class TrackService:
         ]
 
         track_session = init_db(current_app)
-        with track_session() as session:
+        with session_scope(track_session) as session:
 
             track_metadata = MetaData()
             track_projects_table = Table('projects', track_metadata, autoload_with=session.bind)
@@ -75,7 +75,7 @@ class TrackService:
         current_app.logger.info("Fetching works from track database...")
 
         track_session = init_db(current_app)
-        with track_session() as session:
+        with session_scope(track_session) as session:
             track_metadata = MetaData()
             works_table = Table('works', track_metadata, autoload_with=session.bind)
             projects_table = Table('projects', track_metadata, autoload_with=session.bind)
@@ -156,7 +156,7 @@ class TrackService:
         current_app.logger.info("Fetching phases from track database...")
 
         track_session = init_db(current_app)
-        with track_session() as session:
+        with session_scope(track_session) as session:
             track_metadata = MetaData()
             phase_codes_table = Table('phase_codes', track_metadata, autoload_with=session.bind)
             work_types_table = Table('work_types', track_metadata, autoload_with=session.bind)

--- a/jobs/epic-cron/tasks/centre_mail.py
+++ b/jobs/epic-cron/tasks/centre_mail.py
@@ -16,7 +16,7 @@ from datetime import datetime
 
 from flask import current_app
 
-from epic_cron.models.db import init_centre_db
+from epic_cron.models.db import init_centre_db, session_scope
 from epic_cron.models.db import ma
 from epic_cron.processors.centre import PROCESSORS  # noqa: F401 pylint:disable=unused-import
 from epic_cron.repositories.email_repository import EmailRepository
@@ -30,16 +30,13 @@ class CentreMailer:  # pylint:disable=too-few-public-methods
     def send_mail(cls):
         """Send queued Centre emails using registered processors."""
         current_app.logger.info(f'Starting Centre Email At---{datetime.now()}')
-        _session = init_centre_db(current_app)
-        session = _session()
+        session_factory = init_centre_db(current_app)
         ma.init_app(current_app)
 
-        try:
+        with session_scope(session_factory) as session:
             for template_name, processor in PROCESSORS.items():
                 current_app.logger.debug(f'Registering processor for template: {template_name}')
                 CentreEmailService.register_processor(template_name, processor)
 
             repo = EmailRepository(session)
             CentreEmailService.process_email_queue(repo, limit=100)
-        finally:
-            session.close()

--- a/jobs/epic-cron/tasks/epic_public_extractor.py
+++ b/jobs/epic-cron/tasks/epic_public_extractor.py
@@ -4,7 +4,7 @@ from epic_cron.models.external.condition_document import Document as ConditionDo
 from epic_cron.models.external.condition_project import Project as ConditionProjectModel
 from flask import current_app
 
-from epic_cron.models.db import init_conditions_db
+from epic_cron.models.db import init_conditions_db, session_scope
 from epic_cron.services.epic_public_service import EpicPublicService
 
 
@@ -49,7 +49,7 @@ class EpicPublicExtractor:
         project_not_found_examples = []
         existing_examples = []
 
-        with target_session() as session:
+        with session_scope(target_session) as session:
             for doc in documents:
                 try:
                     # Skip if the parent project hasn't been synced yet

--- a/jobs/epic-cron/tasks/pending_access_reminder.py
+++ b/jobs/epic-cron/tasks/pending_access_reminder.py
@@ -16,7 +16,7 @@ from datetime import datetime
 
 from flask import current_app
 
-from submit_cron.models.db import init_centre_db
+from epic_cron.models.db import init_centre_db, session_scope
 from submit_cron.repositories.access_request_repository import AccessRequestRepository
 from submit_cron.services.pending_access_reminder_service import run_pending_access_reminder
 
@@ -29,10 +29,7 @@ class PendingAccessReminder:
         """Query Centre DB for pending access requests and send one reminder email."""
         print("Starting Pending Access Reminder At ", datetime.now())
         session_factory = init_centre_db(current_app)
-        session = session_factory()
-        try:
+        with session_scope(session_factory) as session:
             repo = AccessRequestRepository(session)
             run_pending_access_reminder(repo)
-        finally:
-            session.close()
         print("Completed Pending Access Reminder At ", datetime.now())

--- a/jobs/epic-cron/tasks/phase_extractor.py
+++ b/jobs/epic-cron/tasks/phase_extractor.py
@@ -2,9 +2,8 @@ from datetime import datetime
 
 from epic_cron.models.external.track_phase import TrackPhase as TrackPhaseModel
 from flask import current_app
-from sqlalchemy.exc import IntegrityError
 
-from epic_cron.models.db import init_submit_db
+from epic_cron.models.db import init_submit_session
 from epic_cron.services.track_service import TrackService
 
 
@@ -18,7 +17,7 @@ class PhaseExtractor:
 
         # Initialize submit database session
         current_app.logger.info("Initializing Submit database session...")
-        target_session = init_submit_db(current_app)
+        target_session = init_submit_session(current_app)
 
         try:
             # Step 1: Fetch phase data from Track database
@@ -33,10 +32,6 @@ class PhaseExtractor:
         except Exception as e:
             current_app.logger.error(f"Error during phase extraction: {e}")
             raise
-        finally:
-            # Cleanup Flask-SQLAlchemy session
-            from epic_cron.models import db
-            db.session.remove()
 
     @staticmethod
     def _upsert_phases(track_phases, target_session):
@@ -47,9 +42,6 @@ class PhaseExtractor:
             track_phases: List of phase dictionaries from Track database
             target_session: Database session for submit database
         """
-        from epic_cron.models import db
-        session = db.session
-
         # Statistics tracking
         total_phases = len(track_phases)
         inserts = 0
@@ -59,73 +51,70 @@ class PhaseExtractor:
 
         current_app.logger.info(f"Starting upsert of {total_phases} phases into Submit database...")
 
-        for phase_dict in track_phases:
-            phase_id = phase_dict.get("id")
-            
-            try:
-                # Query for existing phase by id
-                existing_phase = session.query(TrackPhaseModel).filter_by(id=phase_id).first()
+        with target_session() as session:
+            for phase_dict in track_phases:
+                phase_id = phase_dict.get("id")
 
-                if existing_phase:
-                    # Check if phase should be soft deleted
-                    if phase_dict.get("is_deleted", False):
-                        existing_phase.is_deleted = True
-                        existing_phase.is_active = False
-                        existing_phase.updated_date = datetime.utcnow()
-                        existing_phase.updated_by = phase_dict.get("updated_by", "cronjob")
-                        session.commit()
-                        soft_deletes += 1
-                        current_app.logger.info(f"Soft deleted phase ID {phase_id}: {phase_dict.get('name')}")
+                try:
+                    existing_phase = session.query(TrackPhaseModel).filter_by(id=phase_id).first()
+
+                    if existing_phase:
+                        if phase_dict.get("is_deleted", False):
+                            existing_phase.is_deleted = True
+                            existing_phase.is_active = False
+                            existing_phase.updated_date = datetime.utcnow()
+                            existing_phase.updated_by = phase_dict.get("updated_by", "cronjob")
+                            session.commit()
+                            soft_deletes += 1
+                            current_app.logger.info(f"Soft deleted phase ID {phase_id}: {phase_dict.get('name')}")
+                        else:
+                            existing_phase.name = phase_dict.get("name")
+                            existing_phase.ea_act_id = phase_dict.get("ea_act_id")
+                            existing_phase.ea_act_name = phase_dict.get("ea_act_name")
+                            existing_phase.work_type_id = phase_dict.get("work_type_id")
+                            existing_phase.work_type_name = phase_dict.get("work_type_name")
+                            existing_phase.sort_order = phase_dict.get("sort_order")
+                            existing_phase.number_of_days = phase_dict.get("number_of_days")
+                            existing_phase.legislated = phase_dict.get("legislated", False)
+                            existing_phase.enable_submit = False
+                            existing_phase.is_active = phase_dict.get("is_active", True)
+                            existing_phase.is_deleted = phase_dict.get("is_deleted", False)
+                            existing_phase.updated_date = datetime.utcnow()
+                            existing_phase.updated_by = phase_dict.get("updated_by", "cronjob")
+
+                            session.commit()
+                            updates += 1
+                            current_app.logger.debug(f"Updated phase ID {phase_id}: {phase_dict.get('name')}")
                     else:
-                        # Update existing phase
-                        existing_phase.name = phase_dict.get("name")
-                        existing_phase.ea_act_id = phase_dict.get("ea_act_id")
-                        existing_phase.ea_act_name = phase_dict.get("ea_act_name")
-                        existing_phase.work_type_id = phase_dict.get("work_type_id")
-                        existing_phase.work_type_name = phase_dict.get("work_type_name")
-                        existing_phase.sort_order = phase_dict.get("sort_order")
-                        existing_phase.number_of_days = phase_dict.get("number_of_days")
-                        existing_phase.legislated = phase_dict.get("legislated", False)
-                        existing_phase.enable_submit = False  # Keep enable_submit as False
-                        existing_phase.is_active = phase_dict.get("is_active", True)
-                        existing_phase.is_deleted = phase_dict.get("is_deleted", False)
-                        existing_phase.updated_date = datetime.utcnow()
-                        existing_phase.updated_by = phase_dict.get("updated_by", "cronjob")
-                        
+                        new_phase = TrackPhaseModel(
+                            id=phase_dict.get("id"),
+                            name=phase_dict.get("name"),
+                            display_name=phase_dict.get("name"),
+                            ea_act_id=phase_dict.get("ea_act_id"),
+                            ea_act_name=phase_dict.get("ea_act_name"),
+                            work_type_id=phase_dict.get("work_type_id"),
+                            work_type_name=phase_dict.get("work_type_name"),
+                            sort_order=phase_dict.get("sort_order"),
+                            number_of_days=phase_dict.get("number_of_days"),
+                            legislated=phase_dict.get("legislated", False),
+                            enable_submit=False,
+                            is_active=phase_dict.get("is_active", True),
+                            is_deleted=phase_dict.get("is_deleted", False),
+                            created_date=datetime.utcnow(),
+                            created_by=phase_dict.get("created_by", "cronjob"),
+                            updated_by=phase_dict.get("updated_by", "cronjob")
+                        )
+                        session.add(new_phase)
                         session.commit()
-                        updates += 1
-                        current_app.logger.debug(f"Updated phase ID {phase_id}: {phase_dict.get('name')}")
-                else:
-                    # Insert new phase
-                    new_phase = TrackPhaseModel(
-                        id=phase_dict.get("id"),
-                        name=phase_dict.get("name"),
-                        display_name=phase_dict.get("name"),  # Set display_name same as name
-                        ea_act_id=phase_dict.get("ea_act_id"),
-                        ea_act_name=phase_dict.get("ea_act_name"),
-                        work_type_id=phase_dict.get("work_type_id"),
-                        work_type_name=phase_dict.get("work_type_name"),
-                        sort_order=phase_dict.get("sort_order"),
-                        number_of_days=phase_dict.get("number_of_days"),
-                        legislated=phase_dict.get("legislated", False),
-                        enable_submit=False,  # Keep enable_submit as False
-                        is_active=phase_dict.get("is_active", True),
-                        is_deleted=phase_dict.get("is_deleted", False),
-                        created_date=datetime.utcnow(),
-                        created_by=phase_dict.get("created_by", "cronjob"),
-                        updated_by=phase_dict.get("updated_by", "cronjob")
-                    )
-                    session.add(new_phase)
-                    session.commit()
-                    inserts += 1
-                    current_app.logger.debug(f"Inserted new phase ID {phase_id}: {phase_dict.get('name')}")
+                        inserts += 1
+                        current_app.logger.debug(f"Inserted new phase ID {phase_id}: {phase_dict.get('name')}")
 
-            except Exception as e:
-                session.rollback()
-                failed += 1
-                current_app.logger.error(
-                    f"Failed to upsert phase ID {phase_id} ('{phase_dict.get('name')}'): {e}"
-                )
+                except Exception as e:
+                    session.rollback()
+                    failed += 1
+                    current_app.logger.error(
+                        f"Failed to upsert phase ID {phase_id} ('{phase_dict.get('name')}'): {e}"
+                    )
 
         # Log summary
         current_app.logger.info(

--- a/jobs/epic-cron/tasks/phase_extractor.py
+++ b/jobs/epic-cron/tasks/phase_extractor.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from epic_cron.models.external.track_phase import TrackPhase as TrackPhaseModel
 from flask import current_app
 
-from epic_cron.models.db import init_submit_session
+from epic_cron.models.db import init_submit_session, session_scope
 from epic_cron.services.track_service import TrackService
 
 
@@ -51,7 +51,7 @@ class PhaseExtractor:
 
         current_app.logger.info(f"Starting upsert of {total_phases} phases into Submit database...")
 
-        with target_session() as session:
+        with session_scope(target_session) as session:
             for phase_dict in track_phases:
                 phase_id = phase_dict.get("id")
 

--- a/jobs/epic-cron/tasks/project_extractor.py
+++ b/jobs/epic-cron/tasks/project_extractor.py
@@ -6,7 +6,7 @@ from epic_cron.models.external.condition_project import Project as ConditionProj
 from epic_cron.models.external.submit import SubmitProject
 from flask import current_app
 
-from epic_cron.models.db import init_submit_session, init_compliance_db, \
+from epic_cron.models.db import init_submit_session, init_compliance_db, session_scope, \
     init_conditions_db  # Function that initializes DB engines
 from epic_cron.services.track_service import TrackService
 
@@ -57,7 +57,7 @@ class ProjectExtractor:
         updates = 0
         inserts = 0
         
-        with target_session() as session:
+        with session_scope(target_session) as session:
             for index, row in enumerate(track_data):
                 project_dict = dict(row._mapping)
                 current_app.logger.debug(f"Upserting project {index + 1}/{len(track_data)}: {project_dict}")

--- a/jobs/epic-cron/tasks/project_extractor.py
+++ b/jobs/epic-cron/tasks/project_extractor.py
@@ -3,10 +3,10 @@ from enum import Enum
 
 from epic_cron.models.external.compliance_project import Project as ComplianceProjectModel
 from epic_cron.models.external.condition_project import Project as ConditionProjectModel
+from epic_cron.models.external.submit import SubmitProject
 from flask import current_app
-from submit_api.models.project import Project as SubmitProjectModel
 
-from epic_cron.models.db import init_db, init_submit_db, init_compliance_db, \
+from epic_cron.models.db import init_submit_session, init_compliance_db, \
     init_conditions_db  # Function that initializes DB engines
 from epic_cron.services.track_service import TrackService
 
@@ -29,28 +29,20 @@ class ProjectExtractor:
         current_app.logger.info("Initializing database sessions...")
 
         target_session, target_model = cls._get_target_config(target_system)
-        
-        try:
-            # Step 1: Fetch data from track.projects
-            track_data = TrackService.fetch_track_projects()
 
-            # Step 2: Upsert records into the target database (update existing or insert new)
-            cls._upsert_into_target_db(track_data, target_session, target_model, target_system)
+        # Step 1: Fetch data from track.projects
+        track_data = TrackService.fetch_track_projects()
 
-            current_app.logger.info(f"Project Extractor for {target_system.value} completed at {datetime.now()}")
-        finally:
-            # Cleanup session based on type
-            if target_system == TargetSystem.SUBMIT:
-                # Flask-SQLAlchemy cleanup
-                from epic_cron.models import db
-                db.session.remove()
-            # Raw SQLAlchemy sessions are cleaned up in helper methods with context managers
+        # Step 2: Upsert records into the target database (update existing or insert new)
+        cls._upsert_into_target_db(track_data, target_session, target_model, target_system)
+
+        current_app.logger.info(f"Project Extractor for {target_system.value} completed at {datetime.now()}")
 
     @staticmethod
     def _get_target_config(target_system):
         """Get the target database session, model, and required fields based on the target system."""
         if target_system == TargetSystem.SUBMIT:
-            return init_submit_db(current_app), SubmitProjectModel
+            return init_submit_session(current_app), SubmitProject
         if target_system == TargetSystem.CONDITIONS:
             return init_conditions_db(current_app), ConditionProjectModel
         return init_compliance_db(current_app), ComplianceProjectModel
@@ -65,46 +57,100 @@ class ProjectExtractor:
         updates = 0
         inserts = 0
         
-        # Handle Flask-SQLAlchemy vs raw SQLAlchemy differently
-        if target_system == TargetSystem.SUBMIT:
-            # Flask-SQLAlchemy - use db.session directly
-            from epic_cron.models import db
-            session = db.session
-            
+        with target_session() as session:
             for index, row in enumerate(track_data):
                 project_dict = dict(row._mapping)
                 current_app.logger.debug(f"Upserting project {index + 1}/{len(track_data)}: {project_dict}")
 
                 try:
-                    # Query for existing project
-                    existing_project = session.query(target_model).filter_by(id=project_dict["id"]).first()
-                    
-                    if existing_project:
-                        # Check if project is deleted at source
-                        if project_dict.get("is_deleted", False):
-                            # Delete from target if deleted at source
-                            session.delete(existing_project)
-                            current_app.logger.info(f"Deleted project ID {project_dict['id']} (marked as deleted in source)")
+                    if target_system == TargetSystem.SUBMIT:
+                        existing_project = session.query(target_model).filter_by(id=project_dict["id"]).first()
+
+                        if existing_project:
+                            if project_dict.get("is_deleted", False):
+                                session.delete(existing_project)
+                                current_app.logger.info(
+                                    f"Deleted project ID {project_dict['id']} (marked as deleted in source)"
+                                )
+                            else:
+                                existing_project.name = project_dict["name"]
+                                existing_project.epic_guid = project_dict.get("epic_guid")
+                                existing_project.proponent_id = project_dict.get("proponent_id")
+                                existing_project.ea_certificate = project_dict.get("ea_certificate")
+                                updates += 1
+                                current_app.logger.debug(f"Updated existing project ID {project_dict['id']}")
                         else:
-                            # Update existing record
-                            existing_project.name = project_dict['name']
-                            existing_project.epic_guid = project_dict.get("epic_guid")
-                            existing_project.proponent_id = project_dict.get("proponent_id")
-                            existing_project.ea_certificate = project_dict.get("ea_certificate")
-                            updates += 1
-                            current_app.logger.debug(f"Updated existing project ID {project_dict['id']}")
+                            project_instance = target_model(
+                                id=project_dict["id"],
+                                name=project_dict["name"],
+                                epic_guid=project_dict.get("epic_guid"),
+                                proponent_id=project_dict.get("proponent_id"),
+                                ea_certificate=project_dict.get("ea_certificate"),
+                            )
+                            session.add(project_instance)
+                            inserts += 1
+                            current_app.logger.debug(f"Inserted new project ID {project_dict['id']}")
+                    elif target_system == TargetSystem.CONDITIONS:
+                        con_project_id = project_dict.get("epic_guid") or str(project_dict["id"])
+                        existing_project = session.query(target_model).filter_by(project_id=con_project_id).first()
+
+                        if existing_project:
+                            if project_dict.get("is_deleted", False):
+                                session.delete(existing_project)
+                                current_app.logger.info(
+                                    f"Deleted condition project {con_project_id} (marked as deleted in source)"
+                                )
+                            else:
+                                existing_project.project_name = project_dict["name"]
+                                existing_project.project_type = (project_dict.get("type_name") or "").strip()
+                                existing_project.updated_date = datetime.utcnow()
+                                existing_project.updated_by = "cronjob"
+                                updates += 1
+                                current_app.logger.debug(f"Updated existing condition project {con_project_id}")
+                        else:
+                            project_instance = target_model(
+                                project_id=con_project_id,
+                                project_name=project_dict["name"],
+                                project_type=(project_dict.get("type_name") or "").strip(),
+                                created_date=datetime.utcnow(),
+                                updated_date=datetime.utcnow(),
+                                created_by="cronjob",
+                                updated_by="cronjob",
+                            )
+                            session.add(project_instance)
+                            inserts += 1
+                            current_app.logger.debug(f"Inserted new condition project {con_project_id}")
                     else:
-                        # Insert new record
-                        project_instance = target_model(
-                            id=project_dict["id"],
-                            name=project_dict['name'],
-                            epic_guid=project_dict.get("epic_guid"),
-                            proponent_id=project_dict.get("proponent_id"),
-                            ea_certificate=project_dict.get("ea_certificate")
-                        )
-                        session.add(project_instance)
-                        inserts += 1
-                        current_app.logger.debug(f"Inserted new project ID {project_dict['id']}")
+                        existing_project = session.query(target_model).filter_by(id=project_dict["id"]).first()
+
+                        if existing_project:
+                            existing_project.name = project_dict["name"]
+                            existing_project.updated_date = datetime.utcnow()
+                            existing_project.updated_by = "cronjob"
+                            existing_project.is_deleted = project_dict.get("is_deleted", False)
+                            existing_project.is_active = project_dict.get("is_active", True)
+                            updates += 1
+                            current_app.logger.debug(
+                                f"Updated existing compliance project ID {project_dict['id']} "
+                                f"(is_deleted={existing_project.is_deleted}, is_active={existing_project.is_active})"
+                            )
+                        else:
+                            project_instance = target_model(
+                                id=project_dict["id"],
+                                name=project_dict["name"],
+                                created_date=datetime.utcnow(),
+                                updated_date=datetime.utcnow(),
+                                created_by="cronjob",
+                                updated_by="cronjob",
+                                is_active=project_dict.get("is_active", True),
+                                is_deleted=project_dict.get("is_deleted", False),
+                            )
+                            session.add(project_instance)
+                            inserts += 1
+                            current_app.logger.debug(
+                                f"Inserted new compliance project ID {project_dict['id']} "
+                                f"(is_deleted={project_instance.is_deleted}, is_active={project_instance.is_active})"
+                            )
 
                     session.commit()
                     successful_upserts += 1
@@ -121,92 +167,3 @@ class ProjectExtractor:
             )
             if failed_upserts > 0:
                 current_app.logger.warning(f"Summary: Failed to upsert {failed_upserts} records.")
-        else:
-            # Raw SQLAlchemy - use context manager
-            with target_session() as session:
-                for index, row in enumerate(track_data):
-                    project_dict = dict(row._mapping)
-                    current_app.logger.debug(f"Upserting project {index + 1}/{len(track_data)}: {project_dict}")
-
-                    try:
-                        if target_system == TargetSystem.CONDITIONS:
-                            # con repo uses epic_guid as project_id
-                            con_project_id = project_dict.get("epic_guid") or str(project_dict["id"])
-                            
-                            # Query for existing project
-                            existing_project = session.query(target_model).filter_by(project_id=con_project_id).first()
-                            
-                            if existing_project:
-                                # Check if project is deleted at source
-                                if project_dict.get("is_deleted", False):
-                                    # Delete from target if deleted at source
-                                    session.delete(existing_project)
-                                    current_app.logger.info(f"Deleted condition project {con_project_id} (marked as deleted in source)")
-                                else:
-                                    # Update existing record
-                                    existing_project.project_name = project_dict["name"]
-                                    existing_project.project_type = (project_dict.get("type_name") or "").strip()
-                                    existing_project.updated_date = datetime.utcnow()
-                                    existing_project.updated_by = "cronjob"
-                                    updates += 1
-                                    current_app.logger.debug(f"Updated existing condition project {con_project_id}")
-                            else:
-                                # Insert new record
-                                project_instance = target_model(
-                                    project_id=con_project_id,
-                                    project_name=project_dict["name"],
-                                    project_type=(project_dict.get("type_name") or "").strip(),
-                                    created_date=datetime.utcnow(),
-                                    updated_date=datetime.utcnow(),
-                                    created_by="cronjob",
-                                    updated_by="cronjob",
-                                )
-                                session.add(project_instance)
-                                inserts += 1
-                                current_app.logger.debug(f"Inserted new condition project {con_project_id}")
-                        else:
-                            # Compliance system
-                            # Query for existing project
-                            existing_project = session.query(target_model).filter_by(id=project_dict["id"]).first()
-                            
-                            if existing_project:
-                                # Update existing record - sync ALL fields including is_deleted and is_active
-                                existing_project.name = project_dict['name']
-                                existing_project.updated_date = datetime.utcnow()
-                                existing_project.updated_by = "cronjob"
-                                # Sync is_deleted and is_active from source
-                                existing_project.is_deleted = project_dict.get("is_deleted", False)
-                                existing_project.is_active = project_dict.get("is_active", True)
-                                updates += 1
-                                current_app.logger.debug(f"Updated existing compliance project ID {project_dict['id']} (is_deleted={existing_project.is_deleted}, is_active={existing_project.is_active})")
-                            else:
-                                # Insert new record - use values from source
-                                project_instance = target_model(
-                                    id=project_dict["id"],
-                                    name=project_dict['name'],
-                                    created_date=datetime.utcnow(),
-                                    updated_date=datetime.utcnow(),
-                                    created_by="cronjob",
-                                    updated_by="cronjob",
-                                    is_active=project_dict.get("is_active", True),
-                                    is_deleted=project_dict.get("is_deleted", False)
-                                )
-                                session.add(project_instance)
-                                inserts += 1
-                                current_app.logger.debug(f"Inserted new compliance project ID {project_dict['id']} (is_deleted={project_instance.is_deleted}, is_active={project_instance.is_active})")
-
-                        session.commit()
-                        successful_upserts += 1
-
-                    except Exception as e:
-                        failed_upserts += 1
-                        current_app.logger.error(f"FAILED TO UPSERT PROJECT {project_dict.get('id')}")
-                        current_app.logger.error(f"Error Details: {e}")
-                        current_app.logger.error(f"Failed Data: {project_dict}")
-                        session.rollback()
-
-                current_app.logger.info(
-                    f"Summary: Upserted {successful_upserts} records ({inserts} inserts, {updates} updates) into {target_system.value} database."
-                )
-                if failed_upserts > 0:
-                    current_app.logger.warning(f"Summary: Failed to upsert {failed_upserts} records.")

--- a/jobs/epic-cron/tasks/proponent_extractor.py
+++ b/jobs/epic-cron/tasks/proponent_extractor.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from flask import current_app
-from submit_api.models.proponent import Proponent as SubmitProponentModel
-from epic_cron.models.db import init_submit_db
+from epic_cron.models.db import init_submit_session
+from epic_cron.models.external.submit import SubmitProponent
 from epic_cron.services.track_service import TrackService
 
 
@@ -15,10 +15,10 @@ class ProponentExtractor:
 
         # Initialize target database session
         print("Initializing database sessions...")
-        db = init_submit_db(current_app)
+        submit_session = init_submit_session(current_app)
 
         proponents_data = TrackService.fetch_proponents()
-        cls._sync_proponents(proponents_data, db.session, SubmitProponentModel)
+        cls._sync_proponents(proponents_data, submit_session, SubmitProponent)
 
         print(f"Proponent Extractor completed at {datetime.now()}")
 

--- a/jobs/epic-cron/tasks/proponent_extractor.py
+++ b/jobs/epic-cron/tasks/proponent_extractor.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from flask import current_app
-from epic_cron.models.db import init_submit_session
+from epic_cron.models.db import init_submit_session, session_scope
 from epic_cron.models.external.submit import SubmitProponent
 from epic_cron.services.track_service import TrackService
 
@@ -30,7 +30,7 @@ class ProponentExtractor:
         """
         print(f"Syncing proponents into the SUBMIT database...")
 
-        with target_session() as session:
+        with session_scope(target_session) as session:
             try:
                 # Load all existing proponents to minimize DB round-trips
                 existing_proponents = {p.id: p for p in session.query(target_model).all()}

--- a/jobs/epic-cron/tasks/proponent_status_updater.py
+++ b/jobs/epic-cron/tasks/proponent_status_updater.py
@@ -20,38 +20,39 @@ Business Logic:
 from flask import current_app
 from sqlalchemy import and_, or_
 
-from submit_api.models.proponent import Proponent as SubmitProponentModel
-from submit_api.models.project import Project as SubmitProjectModel
-from submit_api.enums.proponent_status import ProponentStatus
+from epic_cron.models.external.submit import SubmitProject, SubmitProponent
 from epic_cron.services.approved_condition_service import ApprovedConditionService
 from epic_cron.models.external.track_work import TrackWork
 from epic_cron.models.external.track_phase import TrackPhase
 from epic_cron.models.external.work_state import WorkState
+
+STATUS_ELIGIBLE = "ELIGIBLE"
+STATUS_INELIGIBLE = "INELIGIBLE"
 
 
 class ProponentStatusUpdater:
     """Updates proponent eligibility status based on approved conditions and valid works."""
 
     @classmethod
-    def update(cls, db, _=None):
+    def update(cls, session_factory, _=None):
         """Main entry point for updating proponent eligibility status."""
         current_app.logger.info("Running ProponentStatusUpdater...")
         
         try:
-            with db.session() as session:
+            with session_factory() as session:
                 # Find all proponents who should be ELIGIBLE
                 eligible_proponent_ids = cls._find_eligible_proponents(session)
                 
                 # Update proponents to ELIGIBLE status
                 if eligible_proponent_ids:
-                    cls._update_proponent_status(session, eligible_proponent_ids, ProponentStatus.ELIGIBLE)
+                    cls._update_proponent_status(session, eligible_proponent_ids, STATUS_ELIGIBLE)
                 else:
                     current_app.logger.info("No eligible proponents found.")
                 
                 # Find and update proponents who should be INELIGIBLE
                 ineligible_proponent_ids = cls._find_ineligible_proponents(session, eligible_proponent_ids)
                 if ineligible_proponent_ids:
-                    cls._update_proponent_status(session, ineligible_proponent_ids, ProponentStatus.INELIGIBLE)
+                    cls._update_proponent_status(session, ineligible_proponent_ids, STATUS_INELIGIBLE)
                 else:
                     current_app.logger.info("No ineligible proponents found.")
                 
@@ -105,8 +106,8 @@ class ProponentStatusUpdater:
             return set(proponent_ids_from_sync)
         
         # Fallback: Query projects with has_approved_condition flag
-        projects_with_conditions = session.query(SubmitProjectModel.proponent_id).filter(
-            SubmitProjectModel.has_approved_condition == True
+        projects_with_conditions = session.query(SubmitProject.proponent_id).filter(
+            SubmitProject.has_approved_condition == True
         ).distinct().all()
         
         return {p.proponent_id for p in projects_with_conditions}
@@ -128,8 +129,8 @@ class ProponentStatusUpdater:
         # Query: Join track_works -> track_phases -> projects -> proponents
         # Filter for valid works with enable_submit phases
         valid_work_proponents = (
-            session.query(SubmitProjectModel.proponent_id)
-            .join(TrackWork, SubmitProjectModel.id == TrackWork.project_id)
+            session.query(SubmitProject.proponent_id)
+            .join(TrackWork, SubmitProject.id == TrackWork.project_id)
             .join(TrackPhase, TrackWork.current_phase_id == TrackPhase.id)
             .filter(
                 and_(
@@ -165,11 +166,11 @@ class ProponentStatusUpdater:
         """
         # Query all proponents with no status who are not in the eligible list
         ineligible_proponents = (
-            session.query(SubmitProponentModel.id)
+            session.query(SubmitProponent.id)
             .filter(
                 and_(
-                    SubmitProponentModel.status.is_(None),  # No status set
-                    SubmitProponentModel.id.notin_(eligible_proponent_ids) if eligible_proponent_ids else True
+                    SubmitProponent.status.is_(None),  # No status set
+                    SubmitProponent.id.notin_(eligible_proponent_ids) if eligible_proponent_ids else True
                 )
             )
             .all()
@@ -189,17 +190,17 @@ class ProponentStatusUpdater:
         Args:
             session: Database session
             proponent_ids: Set or list of proponent IDs to update
-            status: ProponentStatus enum value to set
+            status: Status value to set
         """
         if not proponent_ids:
             return
         
-        proponents = session.query(SubmitProponentModel).filter(
+        proponents = session.query(SubmitProponent).filter(
             and_(
-                SubmitProponentModel.id.in_(proponent_ids),
+                SubmitProponent.id.in_(proponent_ids),
                 or_(
-                    SubmitProponentModel.status.is_(None),
-                    SubmitProponentModel.status == ProponentStatus.INELIGIBLE
+                    SubmitProponent.status.is_(None),
+                    SubmitProponent.status == STATUS_INELIGIBLE
                 )
             )
         ).all()
@@ -212,6 +213,6 @@ class ProponentStatusUpdater:
         
         session.commit()
         current_app.logger.info(
-            f"Updated {updated_count} proponents to {status.value} status "
+            f"Updated {updated_count} proponents to {status} status "
             f"(out of {len(proponent_ids)} eligible)"
         )

--- a/jobs/epic-cron/tasks/proponent_status_updater.py
+++ b/jobs/epic-cron/tasks/proponent_status_updater.py
@@ -20,6 +20,7 @@ Business Logic:
 from flask import current_app
 from sqlalchemy import and_, or_
 
+from epic_cron.models.db import session_scope
 from epic_cron.models.external.submit import SubmitProject, SubmitProponent
 from epic_cron.services.approved_condition_service import ApprovedConditionService
 from epic_cron.models.external.track_work import TrackWork
@@ -39,7 +40,7 @@ class ProponentStatusUpdater:
         current_app.logger.info("Running ProponentStatusUpdater...")
         
         try:
-            with session_factory() as session:
+            with session_scope(session_factory) as session:
                 # Find all proponents who should be ELIGIBLE
                 eligible_proponent_ids = cls._find_eligible_proponents(session)
                 

--- a/jobs/epic-cron/tasks/ssl_checker.py
+++ b/jobs/epic-cron/tasks/ssl_checker.py
@@ -11,6 +11,8 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import sessionmaker
 from flask import current_app
 
+from epic_cron.models.db import session_scope
+
 
 class SSLChecker:
     """Check SSL certificates for URLs stored in the database."""
@@ -35,64 +37,61 @@ class SSLChecker:
         # Use reflection instead of duplicate model definition
         application_urls = Table('application_urls', metadata, autoload_with=engine)
         
-        Session = sessionmaker(bind=engine)
-        session = Session()
+        session_factory = sessionmaker(bind=engine)
 
         try:
-            cert_cache = {}
+            with session_scope(session_factory) as session:
+                cert_cache = {}
 
-            # Query active URLs
-            query = session.query(application_urls).filter(
-                application_urls.c.is_active == True
-            )
-            urls = query.all()
-            print(f"Found {len(urls)} URLs to check.")
+                # Query active URLs
+                query = session.query(application_urls).filter(
+                    application_urls.c.is_active == True
+                )
+                urls = query.all()
+                print(f"Found {len(urls)} URLs to check.")
 
-            for app_url in urls:
-                print(f"Checking {app_url.app_name} ({app_url.environment}): {app_url.url}")
+                for app_url in urls:
+                    print(f"Checking {app_url.app_name} ({app_url.environment}): {app_url.url}")
 
-                certificate_target = SSLChecker._get_certificate_target(app_url.url)
+                    certificate_target = SSLChecker._get_certificate_target(app_url.url)
 
-                # Skip managed DevOps URLs
-                if "devops.gov.bc.ca" in certificate_target:
-                    print(f"Skipping SSL check for managed URL: {app_url.url}")
-                    SSLChecker._update_url_status(
-                        session, application_urls, app_url.id,
-                        ssl_status='Managed',
-                        ssl_expiry=None,
-                        ssl_error_message=None
-                    )
-                    continue
+                    # Skip managed DevOps URLs
+                    if "devops.gov.bc.ca" in certificate_target:
+                        print(f"Skipping SSL check for managed URL: {app_url.url}")
+                        SSLChecker._update_url_status(
+                            session, application_urls, app_url.id,
+                            ssl_status='Managed',
+                            ssl_expiry=None,
+                            ssl_error_message=None
+                        )
+                        continue
 
-                # Reuse the same certificate lookup for routes on the same host.
-                if certificate_target not in cert_cache:
-                    cert_cache[certificate_target] = SSLChecker._get_ssl_details(certificate_target)
-                cert_details = cert_cache[certificate_target]
-                
-                if cert_details['ssl_expiry']:
-                    ssl_status = SSLChecker._calculate_ssl_status(cert_details['ssl_expiry'])
-                    SSLChecker._update_url_status(
-                        session, application_urls, app_url.id,
-                        ssl_status=ssl_status,
-                        ssl_expiry=cert_details['ssl_expiry'],
-                        ssl_error_message=None
-                    )
-                else:
-                    SSLChecker._update_url_status(
-                        session, application_urls, app_url.id,
-                        ssl_status='Error',
-                        ssl_expiry=None,
-                        ssl_error_message=cert_details['ssl_error_message']
-                    )
-            
-            session.commit()
-            print("SSL Check completed.")
+                    # Reuse the same certificate lookup for routes on the same host.
+                    if certificate_target not in cert_cache:
+                        cert_cache[certificate_target] = SSLChecker._get_ssl_details(certificate_target)
+                    cert_details = cert_cache[certificate_target]
+
+                    if cert_details['ssl_expiry']:
+                        ssl_status = SSLChecker._calculate_ssl_status(cert_details['ssl_expiry'])
+                        SSLChecker._update_url_status(
+                            session, application_urls, app_url.id,
+                            ssl_status=ssl_status,
+                            ssl_expiry=cert_details['ssl_expiry'],
+                            ssl_error_message=None
+                        )
+                    else:
+                        SSLChecker._update_url_status(
+                            session, application_urls, app_url.id,
+                            ssl_status='Error',
+                            ssl_expiry=None,
+                            ssl_error_message=cert_details['ssl_error_message']
+                        )
+
+                session.commit()
+                print("SSL Check completed.")
 
         except Exception as e:
             print(f"Database error: {e}")
-            session.rollback()
-        finally:
-            session.close()
 
     @staticmethod
     def _calculate_ssl_status(expiry_date):
@@ -252,66 +251,64 @@ class SSLChecker:
         metadata = MetaData()
         application_urls = Table("application_urls", metadata, autoload_with=engine)
         email_queue = Table("email_queue", metadata, autoload_with=engine)
-        session = sessionmaker(bind=engine)()
+        session_factory = sessionmaker(bind=engine)
 
         try:
-            if SSLChecker._digest_already_queued(
-                session=session,
-                email_queue=email_queue,
-                report_type=report_type,
-                month_key=month_key,
-            ):
-                print(f"SSL {report_type} digest already queued for {month_key}. Skipping.")
-                return
+            with session_scope(session_factory) as session:
+                if SSLChecker._digest_already_queued(
+                    session=session,
+                    email_queue=email_queue,
+                    report_type=report_type,
+                    month_key=month_key,
+                ):
+                    print(f"SSL {report_type} digest already queued for {month_key}. Skipping.")
+                    return
 
-            urls = session.query(application_urls).filter(
-                application_urls.c.is_active == True
-            ).all()
-            items = SSLChecker._build_digest_items(urls=urls, now=now, next_month_start=next_month_start)
-            summary = SSLChecker._build_summary(items)
-            all_clear = summary["total_action_count"] == 0
+                urls = session.query(application_urls).filter(
+                    application_urls.c.is_active == True
+                ).all()
+                items = SSLChecker._build_digest_items(urls=urls, now=now, next_month_start=next_month_start)
+                summary = SSLChecker._build_summary(items)
+                all_clear = summary["total_action_count"] == 0
 
-            if report_type == "followup" and all_clear:
-                print(f"No outstanding SSL items for follow-up in {month_key}. Skipping.")
-                return
+                if report_type == "followup" and all_clear:
+                    print(f"No outstanding SSL items for follow-up in {month_key}. Skipping.")
+                    return
 
-            recipients = SSLChecker._get_recipients()
-            if not recipients:
-                print("SSL_NOTIFICATION_RECIPIENTS is not configured. Skipping SSL digest queue.")
-                return
+                recipients = SSLChecker._get_recipients()
+                if not recipients:
+                    print("SSL_NOTIFICATION_RECIPIENTS is not configured. Skipping SSL digest queue.")
+                    return
 
-            payload = {
-                "recipients": recipients,
-                "sender": current_app.config.get("SSL_NOTIFICATION_SENDER", "EPIC.centre@gov.bc.ca"),
-                "centre_url": current_app.config.get("EPIC_CENTRE_WEB_URL", "https://centre.eao.gov.bc.ca/application-urls"),
-                "generated_at": now.strftime("%b %d, %Y"),
-                "report_type": report_type,
-                "report_month_label": month_label,
-                "report_month_key": month_key,
-                "environment_label": environment_label,
-                "all_clear": all_clear,
-                "summary": summary,
-                "items": items,
-            }
+                payload = {
+                    "recipients": recipients,
+                    "sender": current_app.config.get("SSL_NOTIFICATION_SENDER", "EPIC.centre@gov.bc.ca"),
+                    "centre_url": current_app.config.get("EPIC_CENTRE_WEB_URL", "https://centre.eao.gov.bc.ca/application-urls"),
+                    "generated_at": now.strftime("%b %d, %Y"),
+                    "report_type": report_type,
+                    "report_month_label": month_label,
+                    "report_month_key": month_key,
+                    "environment_label": environment_label,
+                    "all_clear": all_clear,
+                    "summary": summary,
+                    "items": items,
+                }
 
-            session.execute(
-                email_queue.insert().values(
-                    template_name="ssl_digest_notification.html",
-                    status="PENDING",
-                    payload=payload,
-                    created_at=now,
+                session.execute(
+                    email_queue.insert().values(
+                        template_name="ssl_digest_notification.html",
+                        status="PENDING",
+                        payload=payload,
+                        created_at=now,
+                    )
                 )
-            )
-            session.commit()
-            print(
-                f"Queued SSL {report_type} digest for {month_label} "
-                f"with {summary['total_action_count']} actionable item(s)."
-            )
+                session.commit()
+                print(
+                    f"Queued SSL {report_type} digest for {month_label} "
+                    f"with {summary['total_action_count']} actionable item(s)."
+                )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             print(f"Error generating SSL digest: {exc}")
-            session.rollback()
-        finally:
-            session.close()
 
     @staticmethod
     def _build_digest_items(urls, now, next_month_start):

--- a/jobs/epic-cron/tasks/sync_approved_condition.py
+++ b/jobs/epic-cron/tasks/sync_approved_condition.py
@@ -16,7 +16,7 @@ from datetime import datetime
 
 from flask import current_app
 
-from epic_cron.models.db import init_submit_db, ma
+from epic_cron.models.db import init_submit_db, init_submit_session, ma
 from epic_cron.services.approved_condition_sync_service import ApprovedConditionService
 
 
@@ -27,6 +27,7 @@ class SyncApprovedCondition:  # pylint:disable=too-few-public-methods
     def sync_approved_condition(cls):
         """Update projects having approved condition."""
         init_submit_db(current_app)
+        submit_session = init_submit_session(current_app)
         ma.init_app(current_app)
         current_app.logger.info('Starting Approved Condition Sync---{}'.format(datetime.now()))
-        ApprovedConditionService.sync_projects_with_approved_conditions()
+        ApprovedConditionService.sync_projects_with_approved_conditions(submit_session)

--- a/jobs/epic-cron/tasks/work_extractor.py
+++ b/jobs/epic-cron/tasks/work_extractor.py
@@ -4,7 +4,7 @@ from epic_cron.models.external.track_work import TrackWork as TrackWorkModel
 from flask import current_app
 from sqlalchemy.exc import IntegrityError
 
-from epic_cron.models.db import init_submit_db
+from epic_cron.models.db import init_submit_session
 from epic_cron.services.track_service import TrackService
 
 
@@ -18,7 +18,7 @@ class WorkExtractor:
 
         # Initialize submit database session
         current_app.logger.info("Initializing Submit database session...")
-        target_session = init_submit_db(current_app)
+        target_session = init_submit_session(current_app)
 
         try:
             # Step 1: Fetch work data from Track API
@@ -33,10 +33,6 @@ class WorkExtractor:
         except Exception as e:
             current_app.logger.error(f"Error during work extraction: {e}")
             raise
-        finally:
-            # Cleanup Flask-SQLAlchemy session
-            from epic_cron.models import db
-            db.session.remove()
 
     @staticmethod
     def _upsert_works(track_works, target_session):
@@ -47,9 +43,6 @@ class WorkExtractor:
             track_works: List of work dictionaries from Track API
             target_session: Database session for submit database
         """
-        from epic_cron.models import db
-        session = db.session
-
         # Statistics tracking
         total_works = len(track_works)
         inserts = 0
@@ -60,72 +53,69 @@ class WorkExtractor:
 
         current_app.logger.info(f"Starting upsert of {total_works} works into Submit database...")
 
-        for work_dict in track_works:
-            work_id = work_dict.get("id")
-            
-            try:
-                # Query for existing work by id
-                existing_work = session.query(TrackWorkModel).filter_by(id=work_id).first()
+        with target_session() as session:
+            for work_dict in track_works:
+                work_id = work_dict.get("id")
 
-                if existing_work:
-                    # Check if work should be soft deleted
-                    if work_dict.get("is_deleted", False):
-                        existing_work.is_deleted = True
-                        existing_work.is_active = False
-                        existing_work.updated_date = datetime.utcnow()
-                        existing_work.updated_by = work_dict.get("updated_by", "cronjob")
-                        session.commit()
-                        soft_deletes += 1
-                        current_app.logger.info(f"Soft deleted work ID {work_id}: {work_dict.get('title')}")
+                try:
+                    existing_work = session.query(TrackWorkModel).filter_by(id=work_id).first()
+
+                    if existing_work:
+                        if work_dict.get("is_deleted", False):
+                            existing_work.is_deleted = True
+                            existing_work.is_active = False
+                            existing_work.updated_date = datetime.utcnow()
+                            existing_work.updated_by = work_dict.get("updated_by", "cronjob")
+                            session.commit()
+                            soft_deletes += 1
+                            current_app.logger.info(f"Soft deleted work ID {work_id}: {work_dict.get('title')}")
+                        else:
+                            existing_work.project_id = work_dict.get("project_id")
+                            existing_work.current_phase_id = work_dict.get("current_phase_id")
+                            existing_work.work_state = work_dict.get("work_state")
+                            existing_work.title = work_dict.get("title")
+                            existing_work.is_active = work_dict.get("is_active", True)
+                            existing_work.is_deleted = work_dict.get("is_deleted", False)
+                            existing_work.updated_date = datetime.utcnow()
+                            existing_work.updated_by = work_dict.get("updated_by", "cronjob")
+
+                            session.commit()
+                            updates += 1
+                            current_app.logger.debug(f"Updated work ID {work_id}: {work_dict.get('title')}")
                     else:
-                        # Update existing work
-                        existing_work.project_id = work_dict.get("project_id")
-                        existing_work.current_phase_id = work_dict.get("current_phase_id")
-                        existing_work.work_state = work_dict.get("work_state")
-                        existing_work.title = work_dict.get("title")
-                        existing_work.is_active = work_dict.get("is_active", True)
-                        existing_work.is_deleted = work_dict.get("is_deleted", False)
-                        existing_work.updated_date = datetime.utcnow()
-                        existing_work.updated_by = work_dict.get("updated_by", "cronjob")
-                        
+                        new_work = TrackWorkModel(
+                            id=work_dict.get("id"),
+                            project_id=work_dict.get("project_id"),
+                            current_phase_id=work_dict.get("current_phase_id"),
+                            work_state=work_dict.get("work_state"),
+                            title=work_dict.get("title"),
+                            is_active=work_dict.get("is_active", True),
+                            is_deleted=work_dict.get("is_deleted", False),
+                            created_date=datetime.utcnow(),
+                            created_by=work_dict.get("created_by", "cronjob"),
+                            updated_by=work_dict.get("updated_by", "cronjob")
+                        )
+                        session.add(new_work)
                         session.commit()
-                        updates += 1
-                        current_app.logger.debug(f"Updated work ID {work_id}: {work_dict.get('title')}")
-                else:
-                    # Insert new work
-                    new_work = TrackWorkModel(
-                        id=work_dict.get("id"),
-                        project_id=work_dict.get("project_id"),
-                        current_phase_id=work_dict.get("current_phase_id"),
-                        work_state=work_dict.get("work_state"),
-                        title=work_dict.get("title"),
-                        is_active=work_dict.get("is_active", True),
-                        is_deleted=work_dict.get("is_deleted", False),
-                        created_date=datetime.utcnow(),
-                        created_by=work_dict.get("created_by", "cronjob"),
-                        updated_by=work_dict.get("updated_by", "cronjob")
-                    )
-                    session.add(new_work)
-                    session.commit()
-                    inserts += 1
-                    current_app.logger.debug(f"Inserted new work ID {work_id}: {work_dict.get('title')}")
+                        inserts += 1
+                        current_app.logger.debug(f"Inserted new work ID {work_id}: {work_dict.get('title')}")
 
-            except IntegrityError as ie:
-                session.rollback()
-                skipped += 1
-                error_detail = str(ie.orig) if hasattr(ie, 'orig') else str(ie)
-                current_app.logger.warning(
-                    f"Foreign key constraint error for work ID {work_id} ('{work_dict.get('title')}'). "
-                    f"Error: {error_detail}. "
-                    f"Skipping this work. project_id={work_dict.get('project_id')}, "
-                    f"current_phase_id={work_dict.get('current_phase_id')}"
-                )
-            except Exception as e:
-                session.rollback()
-                failed += 1
-                current_app.logger.error(
-                    f"Failed to upsert work ID {work_id} ('{work_dict.get('title')}'): {e}"
-                )
+                except IntegrityError as ie:
+                    session.rollback()
+                    skipped += 1
+                    error_detail = str(ie.orig) if hasattr(ie, 'orig') else str(ie)
+                    current_app.logger.warning(
+                        f"Foreign key constraint error for work ID {work_id} ('{work_dict.get('title')}'). "
+                        f"Error: {error_detail}. "
+                        f"Skipping this work. project_id={work_dict.get('project_id')}, "
+                        f"current_phase_id={work_dict.get('current_phase_id')}"
+                    )
+                except Exception as e:
+                    session.rollback()
+                    failed += 1
+                    current_app.logger.error(
+                        f"Failed to upsert work ID {work_id} ('{work_dict.get('title')}'): {e}"
+                    )
 
         # Log summary
         current_app.logger.info(

--- a/jobs/epic-cron/tasks/work_extractor.py
+++ b/jobs/epic-cron/tasks/work_extractor.py
@@ -4,7 +4,7 @@ from epic_cron.models.external.track_work import TrackWork as TrackWorkModel
 from flask import current_app
 from sqlalchemy.exc import IntegrityError
 
-from epic_cron.models.db import init_submit_session
+from epic_cron.models.db import init_submit_session, session_scope
 from epic_cron.services.track_service import TrackService
 
 
@@ -53,7 +53,7 @@ class WorkExtractor:
 
         current_app.logger.info(f"Starting upsert of {total_works} works into Submit database...")
 
-        with target_session() as session:
+        with session_scope(target_session) as session:
             for work_dict in track_works:
                 work_id = work_dict.get("id")
 

--- a/jobs/epic-cron/tests/test_dependency_boundaries.py
+++ b/jobs/epic-cron/tests/test_dependency_boundaries.py
@@ -1,0 +1,69 @@
+"""Dependency boundary checks for epic-cron."""
+
+import ast
+from pathlib import Path
+
+
+FORBIDDEN_IMPORTS = {
+    "compliance_api",
+    "condition_api",
+}
+
+SUBMIT_SYNC_FILES = [
+    "invoke_jobs.py",
+    "tasks/phase_extractor.py",
+    "tasks/project_extractor.py",
+    "tasks/proponent_extractor.py",
+    "tasks/proponent_status_updater.py",
+    "tasks/sync_approved_condition.py",
+    "tasks/work_extractor.py",
+    "src/epic_cron/services/approved_condition_service.py",
+    "src/epic_cron/services/approved_condition_sync_service.py",
+]
+
+
+def _python_files():
+    project_root = Path(__file__).resolve().parents[1]
+    for folder_name in ("src", "tasks"):
+        yield from (project_root / folder_name).rglob("*.py")
+    yield project_root / "invoke_jobs.py"
+
+
+def _find_forbidden_imports(path, forbidden_imports):
+    violations = []
+    tree = ast.parse(path.read_text(), filename=str(path))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                package_name = alias.name.split(".")[0]
+                if package_name in forbidden_imports:
+                    violations.append(f"{path}: imports {alias.name}")
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            package_name = node.module.split(".")[0]
+            if package_name in forbidden_imports:
+                violations.append(f"{path}: imports from {node.module}")
+
+    return violations
+
+
+def test_cron_does_not_import_compliance_or_condition_packages():
+    """epic-cron should not import Compliance or Condition application packages."""
+    violations = []
+
+    for path in _python_files():
+        violations.extend(_find_forbidden_imports(path, FORBIDDEN_IMPORTS))
+
+    assert violations == []
+
+
+def test_submit_sync_paths_do_not_import_submit_packages():
+    """Submit sync code should use local models instead of submit_api or submit_cron."""
+    project_root = Path(__file__).resolve().parents[1]
+    violations = []
+
+    for relative_path in SUBMIT_SYNC_FILES:
+        path = project_root / relative_path
+        violations.extend(_find_forbidden_imports(path, {"submit_api", "submit_cron"}))
+
+    assert violations == []


### PR DESCRIPTION
Refactoring cron to avoid tight coupling 

- removed direct Compliance and Condition repo dependencies from the cron build
- moved Submit sync paths away from direct submit_api model imports
- kept Submit mailer behavior unchanged
- added local Submit sync models where needed
- cleaned up non-mailer cron session handling with one shared session helper