### PR TITLE
CENTR-143:BUG - Reminder email for auth originating from MPT email address

### DIFF
--- a/deployments/charts/epic-cron/templates/configmap.yaml
+++ b/deployments/charts/epic-cron/templates/configmap.yaml
@@ -23,6 +23,7 @@ data:
   # SUBMIT configuration
   WEB_URL: "{{ .Values.SUBMIT.web.url }}"
   SENDER_EMAIL: "{{ .Values.SUBMIT.sender.email }}"
+  CENTRE_SENDER_EMAIL: "{{ .Values.CENTRE.senderEmail }}"
   STAFF_SUPPORT_MAIL_ID: "{{ .Values.SUBMIT.staffSupportMailId }}"
   SIGNUP_URL_PATH: "{{ .Values.SUBMIT.signupUrlPath }}"
   # Keycloak configuration

--- a/deployments/charts/epic-cron/templates/deployment.yaml
+++ b/deployments/charts/epic-cron/templates/deployment.yaml
@@ -168,6 +168,11 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.name }}-config
                   key: SENDER_EMAIL
+            - name: CENTRE_SENDER_EMAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.name }}-config
+                  key: CENTRE_SENDER_EMAIL
             - name: STAFF_SUPPORT_MAIL_ID
               valueFrom:
                 configMapKeyRef:

--- a/jobs/epic-cron/config.py
+++ b/jobs/epic-cron/config.py
@@ -132,6 +132,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     # Submit Web Configuration
     WEB_URL = os.getenv('WEB_URL')
     SENDER_EMAIL = os.getenv('SENDER_EMAIL')
+    CENTRE_SENDER_EMAIL = os.getenv('CENTRE_SENDER_EMAIL')
     STAFF_SUPPORT_MAIL_ID = os.getenv('STAFF_SUPPORT_MAIL_ID', '')
     SIGNUP_URL_PATH = os.getenv('SIGNUP_URL_PATH', '/proponent/registration')
     

--- a/jobs/epic-cron/sample.env
+++ b/jobs/epic-cron/sample.env
@@ -150,6 +150,7 @@ CHES_BASE_URL=https://ches-dev.api.gov.bc.ca
 # Sender Email Address
 # Email address used as the sender for all outgoing emails
 SENDER_EMAIL=EAO.ManagementPlanSupport@gov.bc.ca
+CENTRE_SENDER_EMAIL=
 
 # Staff Support Email
 # Email address for staff support inquiries

--- a/jobs/epic-cron/src/epic_cron/services/pending_access_reminder_service.py
+++ b/jobs/epic-cron/src/epic_cron/services/pending_access_reminder_service.py
@@ -72,7 +72,7 @@ def run_pending_access_reminder(repository: AccessRequestRepository) -> bool:
     hours = current_app.config.get("PENDING_ACCESS_REMINDER_HOURS", 48)
     recipient = (current_app.config.get("PENDING_ACCESS_REMINDER_EMAIL") or "").strip()
     base_url = (current_app.config.get("REQUEST_ACCESS_BASE_URL") or "").strip()
-    sender = current_app.config.get("SENDER_EMAIL") or ""
+    sender = current_app.config.get("CENTRE_SENDER_EMAIL") or ""
 
     if not recipient:
         logger.warning(
@@ -80,7 +80,7 @@ def run_pending_access_reminder(repository: AccessRequestRepository) -> bool:
         )
         return False
     if not sender:
-        raise BadRequestError("SENDER_EMAIL is not configured")
+        raise BadRequestError("CENTRE_SENDER_EMAIL is not configured")
 
     pending = repository.find_pending_older_than_hours(hours)
     if not pending:


### PR DESCRIPTION
**Problem**
A non-Superuser TRACK email was appearing as the sender for Centre access request reminder notifications because the service shared the general SENDER_EMAIL config used across multiple apps.

**Solution**
Introduce CENTRE_SENDER_EMAIL specifically for pending access reminder emails, decoupling it from the shared SENDER_EMAIL.

**Changes**

- pending_access_reminder_service.py — use CENTRE_SENDER_EMAIL instead of SENDER_EMAIL
- config.py / sample.env — added CENTRE_SENDER_EMAIL
- Helm charts — added CENTRE_SENDER_EMAIL to configmap and deployment env