### PR TITLE
Update deployment signup url path

### DIFF
--- a/deployments/charts/epic-cron/values.yaml
+++ b/deployments/charts/epic-cron/values.yaml
@@ -29,7 +29,7 @@ SUBMIT:
   sender:
     email: "EAO.ManagementPlanSupport@gov.bc.ca"
   staffSupportMailId: ""
-  signupUrlPath: "/proponent/registration"
+  signupUrlPath: "/proponent/account-registration"
 
 COMPLIANCE:
   database:


### PR DESCRIPTION
**Issue**
When a value is updated manually in the OpenShift ConfigMap, it will get overwritten when a new deployment is done (either via GitHub Actions or a new rollout). This occurred for the `signupUrlPath` value during the QA testing, causing invitation urls to redirect to a legacy page, resulting in the "Need Access" page being displayed during the sign up process.

**Fix**
Updating the value in the `values.yaml` will prevent this in the future.