### PR TITLE
CENTR-143:BUG - Reminder email for auth originating from MPT email address

### DIFF
--- a/jobs/epic-cron/invoke_jobs.py
+++ b/jobs/epic-cron/invoke_jobs.py
@@ -178,7 +178,8 @@ if __name__ == "__main__":
     if not args:
         logger.error(
             "You must provide a job type: "
-            "SUBMIT/COMPLIANCE/EMAIL/SYNC_CONDITION/SCAN_VIRUS/EXTRACT_WORK/EXTRACT_PHASE/CHECK_SSL"
+            "SUBMIT/COMPLIANCE/EMAIL/SYNC_CONDITION/PENDING_ACCESS_REMINDER/"
+            "SCAN_VIRUS/EXTRACT_WORK/EXTRACT_PHASE/CHECK_SSL"
         )
         sys.exit(1)
 
@@ -194,6 +195,9 @@ if __name__ == "__main__":
 
     elif job_type == "SYNC_STAFF_WORK_ROLE":
         run("SYNC_STAFF_WORK_ROLE")
+
+    elif job_type == "PENDING_ACCESS_REMINDER":
+        run("PENDING_ACCESS_REMINDER")
 
     elif job_type == "EXTRACT_WORK":
         try:


### PR DESCRIPTION
- invoke_jobs.py already implemented the PENDING_ACCESS_REMINDER job in run(), but the CLI arg-parser in __main__ had no matching elif branch, so invoking it (python invoke_jobs.py PENDING_ACCESS_REMINDER) fell through to the catch-all else, which tried to parse it as a TargetSystem enum and failed with Invalid job type 'PENDING_ACCESS_REMINDER'.
- Added the missing elif job_type == "PENDING_ACCESS_REMINDER": run("PENDING_ACCESS_REMINDER") branch.
- Added PENDING_ACCESS_REMINDER to the usage message shown when no job type is provided.